### PR TITLE
Add selectable storefront themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,17 @@ graph TB
    npm install
    ```
 
-2. **Automated Deployment**
+2. **Preview Themes (Optional)**
+   ```bash
+   npm run preview:theme
+   ```
+   Select a theme to view the storefront with sample products. Exit the dev server with `Ctrl+C` when done.
+
+3. **Automated Deployment**
    ```bash
    npm run setup
    ```
-   
+
    **Setup prompts:**
    - **Project Name** - Unique name for your store (e.g., "my-electronics-store")
    - **Cloudflare API Token** - [Get token here](https://dash.cloudflare.com/profile/api-tokens)
@@ -86,7 +92,7 @@ graph TB
    - **Stripe Publishable Key** - From your Stripe dashboard
    - **Admin Password** - Custom password (default: admin123)
 
-3. **🎉 Your Store is Live!**
+4. **🎉 Your Store is Live!**
    
    Access your store at: `https://your-project-name.workers.dev`
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "setup": "node scripts/setup.js",
+    "preview:theme": "node scripts/preview-themes.js",
     "deploy": "node scripts/deploy.js",
     "worker:dev": "wrangler dev --local",
     "wrangler:login": "wrangler auth login"

--- a/scripts/preview-themes.js
+++ b/scripts/preview-themes.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { copyFileSync } from 'fs'
+import { execSync } from 'child_process'
+import { createInterface } from 'readline'
+
+const rl = createInterface({
+  input: process.stdin,
+  output: process.stdout
+})
+
+function question(prompt) {
+  return new Promise(resolve => rl.question(prompt, resolve))
+}
+
+async function preview() {
+  const themeInput = await question('Preview theme (trendy, modern, elegant) [trendy]: ')
+  const selectedTheme = (themeInput.trim().toLowerCase()) || 'trendy'
+  const validThemes = ['trendy', 'modern', 'elegant']
+  if (!validThemes.includes(selectedTheme)) {
+    console.error('❌ Invalid theme selected!')
+    process.exit(1)
+  }
+
+  try {
+    copyFileSync(`src/themes/${selectedTheme}.css`, 'src/theme.css')
+    console.log(`✅ Applied ${selectedTheme} theme for preview\n`)
+  } catch (err) {
+    console.error('❌ Failed to apply theme:', err.message)
+    process.exit(1)
+  }
+
+  rl.close()
+
+  console.log('🛍️ Starting dev server with mock data...')
+  execSync('npm run dev', {
+    stdio: 'inherit',
+    env: { ...process.env, VITE_USE_MOCK_DATA: 'true' }
+  })
+}
+
+preview().catch(err => {
+  console.error('Preview failed:', err)
+  process.exit(1)
+})

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from 'child_process'
-import { readFileSync, writeFileSync } from 'fs'
+import { readFileSync, writeFileSync, copyFileSync, rmSync } from 'fs'
 import { createInterface } from 'readline'
 
 const rl = createInterface({
@@ -47,6 +47,10 @@ async function setup() {
   
   console.log(`✅ Using sanitized project name: ${sanitizedProjectName}\n`)
 
+  const themeInput = await question('Starter Theme (trendy, modern, elegant) [trendy]: ')
+  const selectedTheme = (themeInput.trim().toLowerCase()) || 'trendy'
+  console.log(`✅ Selected ${selectedTheme} theme\n`)
+
   // Collect required credentials
   console.log('🔑 Required Credentials:\n')
   
@@ -57,6 +61,20 @@ async function setup() {
   const adminPassword = await question('Admin Password (default: admin123): ') || 'admin123'
   
   rl.close()
+
+  const validThemes = ['trendy', 'modern', 'elegant']
+  if (!validThemes.includes(selectedTheme)) {
+    console.error('❌ Invalid theme selected!')
+    process.exit(1)
+  }
+  try {
+    copyFileSync(`src/themes/${selectedTheme}.css`, 'src/theme.css')
+    rmSync('src/themes', { recursive: true, force: true })
+    console.log(`✅ Applied ${selectedTheme} theme`)
+  } catch (err) {
+    console.error('❌ Failed to apply theme:', err.message)
+    process.exit(1)
+  }
 
   // Install Wrangler CLI if not present
   try {

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./theme.css";
 
 /* Custom animations for cart */
 @keyframes fade-in {

--- a/src/mockData.js
+++ b/src/mockData.js
@@ -1,0 +1,37 @@
+export const mockCollections = [
+  { id: 'col-1', name: 'Accessories' },
+  { id: 'col-2', name: 'Apparel' }
+]
+
+export const mockProducts = [
+  {
+    id: 'prod-1',
+    name: 'Stylish Hat',
+    tagline: 'Keep it cool',
+    price: 29.99,
+    currency: 'USD',
+    images: ['https://via.placeholder.com/400x300'],
+    collectionId: 'col-1',
+    stripePriceId: ''
+  },
+  {
+    id: 'prod-2',
+    name: 'Comfy Hoodie',
+    tagline: 'Cozy up',
+    price: 59.99,
+    currency: 'USD',
+    images: ['https://via.placeholder.com/400x300'],
+    collectionId: 'col-2',
+    stripePriceId: ''
+  },
+  {
+    id: 'prod-3',
+    name: 'Running Sneakers',
+    tagline: 'Run in style',
+    price: 89.99,
+    currency: 'USD',
+    images: ['https://via.placeholder.com/400x300'],
+    collectionId: 'col-2',
+    stripePriceId: ''
+  }
+]

--- a/src/pages/storefront/Storefront.jsx
+++ b/src/pages/storefront/Storefront.jsx
@@ -4,12 +4,14 @@ import { Hero } from '../../components/storefront/Hero'
 import { Carousel } from '../../components/storefront/Carousel'
 import { ProductCard } from '../../components/storefront/ProductCard'
 import { Button } from '../../components/ui/button'
+import { mockProducts, mockCollections } from '../../mockData'
 
 export function Storefront() {
   const [products, setProducts] = useState([])
   const [collections, setCollections] = useState([])
   const [selectedCollection, setSelectedCollection] = useState(null)
   const [loading, setLoading] = useState(true)
+  const useMockData = import.meta.env.VITE_USE_MOCK_DATA === 'true'
 
   useEffect(() => {
     fetchData()
@@ -18,7 +20,13 @@ export function Storefront() {
   const fetchData = async () => {
     try {
       setLoading(true)
-      
+
+      if (useMockData) {
+        setProducts(mockProducts)
+        setCollections(mockCollections)
+        return
+      }
+
       // Fetch products and collections
       const [productsResponse, collectionsResponse] = await Promise.all([
         fetch('/api/products'),

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,34 @@
+:root {
+  --color-background: #ffffff;
+  --color-text-primary: #111827;
+  --color-text-secondary: #4b5563;
+  --color-accent: #9333ea;
+  --color-muted: #f3f4f6;
+  --color-border: #e5e7eb;
+}
+
+@layer base {
+  body {
+    background-color: var(--color-background);
+    color: var(--color-text-primary);
+  }
+}
+
+@layer utilities {
+  .bg-white { background-color: var(--color-background) !important; }
+  .text-gray-900 { color: var(--color-text-primary) !important; }
+  .text-gray-600 { color: var(--color-text-secondary) !important; }
+  .text-gray-500 { color: var(--color-text-secondary) !important; }
+  .text-gray-400 { color: var(--color-text-secondary) !important; }
+  .bg-gray-50 { background-color: var(--color-muted) !important; }
+  .bg-gray-100 { background-color: var(--color-muted) !important; }
+  .hover\\:bg-gray-50:hover { background-color: var(--color-muted) !important; }
+  .hover\\:bg-gray-100:hover { background-color: var(--color-muted) !important; }
+  .text-purple-600 { color: var(--color-accent) !important; }
+  .hover\\:text-purple-600:hover { color: var(--color-accent) !important; }
+  .bg-purple-600 { background-color: var(--color-accent) !important; }
+  .hover\\:bg-purple-600:hover { background-color: var(--color-accent) !important; }
+  .border-b { border-bottom-color: var(--color-border) !important; }
+  .border-t { border-top-color: var(--color-border) !important; }
+  .border { border-color: var(--color-border) !important; }
+}

--- a/src/themes/elegant.css
+++ b/src/themes/elegant.css
@@ -1,0 +1,34 @@
+:root {
+  --color-background: #f5f5f4;
+  --color-text-primary: #2e2e2e;
+  --color-text-secondary: #57534e;
+  --color-accent: #b45309;
+  --color-muted: #fafaf9;
+  --color-border: #e7e5e4;
+}
+
+@layer base {
+  body {
+    background-color: var(--color-background);
+    color: var(--color-text-primary);
+  }
+}
+
+@layer utilities {
+  .bg-white { background-color: var(--color-background) !important; }
+  .text-gray-900 { color: var(--color-text-primary) !important; }
+  .text-gray-600 { color: var(--color-text-secondary) !important; }
+  .text-gray-500 { color: var(--color-text-secondary) !important; }
+  .text-gray-400 { color: var(--color-text-secondary) !important; }
+  .bg-gray-50 { background-color: var(--color-muted) !important; }
+  .bg-gray-100 { background-color: var(--color-muted) !important; }
+  .hover\\:bg-gray-50:hover { background-color: var(--color-muted) !important; }
+  .hover\\:bg-gray-100:hover { background-color: var(--color-muted) !important; }
+  .text-purple-600 { color: var(--color-accent) !important; }
+  .hover\\:text-purple-600:hover { color: var(--color-accent) !important; }
+  .bg-purple-600 { background-color: var(--color-accent) !important; }
+  .hover\\:bg-purple-600:hover { background-color: var(--color-accent) !important; }
+  .border-b { border-bottom-color: var(--color-border) !important; }
+  .border-t { border-top-color: var(--color-border) !important; }
+  .border { border-color: var(--color-border) !important; }
+}

--- a/src/themes/modern.css
+++ b/src/themes/modern.css
@@ -1,0 +1,34 @@
+:root {
+  --color-background: #ffffff;
+  --color-text-primary: #111111;
+  --color-text-secondary: #6b7280;
+  --color-accent: #ef4444;
+  --color-muted: #f5f5f5;
+  --color-border: #e5e7eb;
+}
+
+@layer base {
+  body {
+    background-color: var(--color-background);
+    color: var(--color-text-primary);
+  }
+}
+
+@layer utilities {
+  .bg-white { background-color: var(--color-background) !important; }
+  .text-gray-900 { color: var(--color-text-primary) !important; }
+  .text-gray-600 { color: var(--color-text-secondary) !important; }
+  .text-gray-500 { color: var(--color-text-secondary) !important; }
+  .text-gray-400 { color: var(--color-text-secondary) !important; }
+  .bg-gray-50 { background-color: var(--color-muted) !important; }
+  .bg-gray-100 { background-color: var(--color-muted) !important; }
+  .hover\\:bg-gray-50:hover { background-color: var(--color-muted) !important; }
+  .hover\\:bg-gray-100:hover { background-color: var(--color-muted) !important; }
+  .text-purple-600 { color: var(--color-accent) !important; }
+  .hover\\:text-purple-600:hover { color: var(--color-accent) !important; }
+  .bg-purple-600 { background-color: var(--color-accent) !important; }
+  .hover\\:bg-purple-600:hover { background-color: var(--color-accent) !important; }
+  .border-b { border-bottom-color: var(--color-border) !important; }
+  .border-t { border-top-color: var(--color-border) !important; }
+  .border { border-color: var(--color-border) !important; }
+}

--- a/src/themes/trendy.css
+++ b/src/themes/trendy.css
@@ -1,0 +1,34 @@
+:root {
+  --color-background: #ffffff;
+  --color-text-primary: #111827;
+  --color-text-secondary: #4b5563;
+  --color-accent: #9333ea;
+  --color-muted: #f3f4f6;
+  --color-border: #e5e7eb;
+}
+
+@layer base {
+  body {
+    background-color: var(--color-background);
+    color: var(--color-text-primary);
+  }
+}
+
+@layer utilities {
+  .bg-white { background-color: var(--color-background) !important; }
+  .text-gray-900 { color: var(--color-text-primary) !important; }
+  .text-gray-600 { color: var(--color-text-secondary) !important; }
+  .text-gray-500 { color: var(--color-text-secondary) !important; }
+  .text-gray-400 { color: var(--color-text-secondary) !important; }
+  .bg-gray-50 { background-color: var(--color-muted) !important; }
+  .bg-gray-100 { background-color: var(--color-muted) !important; }
+  .hover\\:bg-gray-50:hover { background-color: var(--color-muted) !important; }
+  .hover\\:bg-gray-100:hover { background-color: var(--color-muted) !important; }
+  .text-purple-600 { color: var(--color-accent) !important; }
+  .hover\\:text-purple-600:hover { color: var(--color-accent) !important; }
+  .bg-purple-600 { background-color: var(--color-accent) !important; }
+  .hover\\:bg-purple-600:hover { background-color: var(--color-accent) !important; }
+  .border-b { border-bottom-color: var(--color-border) !important; }
+  .border-t { border-top-color: var(--color-border) !important; }
+  .border { border-color: var(--color-border) !important; }
+}


### PR DESCRIPTION
## Summary
- add script to preview themes with mock products
- load mock catalog when preview env flag is set
- document optional theme preview step

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 28 errors, 4 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c202f436108329b85c33d44a99c18b