### PR TITLE
Use secure admin session tokens

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -5,7 +5,19 @@ const ADMIN_TOKEN_KEY = 'openshop_admin_token'
 
 // Generate a simple session token (in production, use proper JWT or session management)
 export function generateAdminToken() {
-  return btoa(Date.now() + Math.random().toString(36)).replace(/[^a-zA-Z0-9]/g, '')
+  const cryptoObj = typeof globalThis !== 'undefined' ? globalThis.crypto : null
+
+  if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+    return cryptoObj.randomUUID().replace(/-/g, '')
+  }
+
+  if (cryptoObj && typeof cryptoObj.getRandomValues === 'function') {
+    const bytes = new Uint8Array(32)
+    cryptoObj.getRandomValues(bytes)
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+  }
+
+  throw new Error('Secure random number generator is not available')
 }
 
 // Store admin token in localStorage


### PR DESCRIPTION
## Summary
- replace Math.random() usage in the worker and client auth helper with crypto-secure generators
- hash admin session tokens before persisting to KV and update verification to compare hashed values
- reuse secure random helpers in the worker for multipart boundaries and media identifiers

## Testing
- `npm run lint` *(fails: pre-existing lint errors unrelated to this change)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_b_68dd7273297483298e33422693cf1596