### PR TITLE
Refactor admin media tools and add component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "setup": "node scripts/setup.js",
     "deploy": "node scripts/deploy.js",
     "worker:dev": "wrangler dev --local",
-    "wrangler:login": "wrangler auth login"
+    "wrangler:login": "wrangler auth login",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.1",
@@ -36,11 +38,16 @@
     "@eslint/js": "^9.33.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^5.0.0",
     "eslint": "^9.33.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "vite": "^7.1.2"
+    "jsdom": "^25.0.1",
+    "vite": "^7.1.2",
+    "vitest": "^2.1.4"
   }
 }

--- a/src/components/admin/ExistingMediaModal.jsx
+++ b/src/components/admin/ExistingMediaModal.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Button } from '../ui/button'
 import { adminApiRequest } from '../../lib/auth'
-import { normalizeImageUrl } from '../../lib/utils'
+import MediaModalLayout from './media/MediaModalLayout'
+import MediaGrid from './media/MediaGrid'
 
 export default function ExistingMediaModal({ open, onClose, onPick }) {
   const [items, setItems] = useState([])
@@ -36,44 +37,28 @@ export default function ExistingMediaModal({ open, onClose, onPick }) {
     onClose?.()
   }
 
-  if (!open) return null
-
   return (
-    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50" onClick={onClose}>
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-3xl mx-4 flex flex-col max-h-[80vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
-        <div className="p-4 border-b flex items-center justify-between flex-shrink-0">
-          <h3 className="text-lg font-semibold">Select existing media</h3>
-        </div>
-        <div className="p-4 flex-1 overflow-y-auto">
-          {isLoading ? (
-            <p className="text-sm text-gray-500">Loading…</p>
-          ) : error ? (
-            <p className="text-sm text-red-600">{error}</p>
-          ) : items.length === 0 ? (
-            <p className="text-sm text-gray-600">No media yet. Add images in the Media tab.</p>
-          ) : (
-            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
-              {items.map((it) => (
-                <button
-                  key={it.id}
-                  type="button"
-                  className="aspect-square rounded border overflow-hidden bg-white hover:ring-2 hover:ring-purple-500"
-                  title={it.filename || it.url}
-                  onClick={() => handlePick(it.url)}
-                >
-                  <img src={normalizeImageUrl(it.url)} alt={it.filename || 'media'} className="w-full h-full object-cover" />
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-        <div className="p-3 border-t flex justify-end flex-shrink-0">
-          <Button type="button" variant="outline" onClick={onClose}>Close</Button>
-        </div>
-      </div>
-    </div>
+    <MediaModalLayout
+      open={open}
+      title="Select existing media"
+      onClose={onClose}
+      footer={
+        <Button type="button" variant="outline" onClick={onClose}>
+          Close
+        </Button>
+      }
+    >
+      {isLoading ? (
+        <p className="text-sm text-gray-500">Loading…</p>
+      ) : error ? (
+        <p className="text-sm text-red-600">{error}</p>
+      ) : (
+        <MediaGrid
+          items={items}
+          onSelect={handlePick}
+          emptyMessage="No media yet. Add images in the Media tab."
+        />
+      )}
+    </MediaModalLayout>
   )
 }
-
-
-

--- a/src/components/admin/MediaPickerModal.jsx
+++ b/src/components/admin/MediaPickerModal.jsx
@@ -1,11 +1,23 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Input } from '../ui/input'
 import { Button } from '../ui/button'
 import { adminApiRequest } from '../../lib/auth'
 import { normalizeImageUrl } from '../../lib/utils'
+import MediaModalLayout from './media/MediaModalLayout'
+import MediaTabs from './media/MediaTabs'
+import MediaGrid from './media/MediaGrid'
+import ReferenceSlots from './media/ReferenceSlots'
+import { useDriveStatus } from './media/useDriveStatus'
+import { buildDataUrl, fileToDataUrl, parseDataUrl } from './media/mediaUtils'
+
+const TABS = [
+  { id: 'library', label: 'Library' },
+  { id: 'link', label: 'Link' },
+  { id: 'generate', label: 'Generate' },
+]
 
 export default function MediaPickerModal({ open, onClose, onPick }) {
-  const [activeTab, setActiveTab] = useState('library') // 'library' | 'link' | 'generate'
+  const [activeTab, setActiveTab] = useState('library')
   const [library, setLibrary] = useState([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
@@ -14,71 +26,75 @@ export default function MediaPickerModal({ open, onClose, onPick }) {
   const [files, setFiles] = useState([])
   const [resultBase64, setResultBase64] = useState('')
   const [resultMime, setResultMime] = useState('image/png')
-  const [isGenerating, setIsGenerating] = useState(false)
-  const [isUploading, setIsUploading] = useState(false)
-  const [driveConnected, setDriveConnected] = useState(false)
-  const [genError, setGenError] = useState('')
   const [filename, setFilename] = useState('openshop-image.png')
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [genError, setGenError] = useState('')
+  const [isUploading, setIsUploading] = useState(false)
+  const { driveConnected, checkDriveStatus, disconnectDrive, error: driveError, setError: setDriveError } = useDriveStatus()
 
-  useEffect(() => {
-    if (!open) return
-    setActiveTab('library')
-    setError('')
-    setLinkValue('')
-    loadLibrary()
-    checkDriveStatus()
-  }, [open])
-
-  async function loadLibrary() {
+  const loadLibrary = useCallback(async () => {
     try {
       setIsLoading(true)
       setError('')
       const [prodRes, collRes, settingsRes] = await Promise.all([
         fetch('/api/products'),
         fetch('/api/collections'),
-        fetch('/api/store-settings')
+        fetch('/api/store-settings'),
       ])
       const [products, collections, settings] = await Promise.all([
         prodRes.ok ? prodRes.json() : [],
         collRes.ok ? collRes.json() : [],
-        settingsRes.ok ? settingsRes.json() : {}
+        settingsRes.ok ? settingsRes.json() : {},
       ])
       const urls = new Set()
-
-      // Products images and variant images
-      for (const p of (products || [])) {
-        if (Array.isArray(p.images)) {
-          for (const u of p.images) if (u) urls.add(String(u))
+      for (const product of products || []) {
+        if (Array.isArray(product.images)) {
+          for (const url of product.images) if (url) urls.add(String(url))
         }
-        if (Array.isArray(p.variants)) {
-          for (const v of p.variants) {
-            if (v?.selectorImageUrl) urls.add(String(v.selectorImageUrl))
-            if (v?.displayImageUrl) urls.add(String(v.displayImageUrl))
-          }
+        for (const variant of product.variants || []) {
+          if (variant?.selectorImageUrl) urls.add(String(variant.selectorImageUrl))
+          if (variant?.displayImageUrl) urls.add(String(variant.displayImageUrl))
         }
-        if (Array.isArray(p.variants2)) {
-          for (const v of p.variants2) {
-            if (v?.selectorImageUrl) urls.add(String(v.selectorImageUrl))
-            if (v?.displayImageUrl) urls.add(String(v.displayImageUrl))
-          }
+        for (const variant of product.variants2 || []) {
+          if (variant?.selectorImageUrl) urls.add(String(variant.selectorImageUrl))
+          if (variant?.displayImageUrl) urls.add(String(variant.displayImageUrl))
         }
       }
-
-      // Collections hero images
-      for (const c of (collections || [])) {
-        if (c?.heroImage) urls.add(String(c.heroImage))
+      for (const collection of collections || []) {
+        if (collection?.heroImage) urls.add(String(collection.heroImage))
       }
-
-      // Store settings images
       if (settings?.logoImageUrl) urls.add(String(settings.logoImageUrl))
       if (settings?.heroImageUrl) urls.add(String(settings.heroImageUrl))
-
-      setLibrary(Array.from(urls))
-    } catch (e) {
+      setLibrary(Array.from(urls).map((url) => normalizeImageUrl(url)))
+    } catch (_) {
       setError('Failed to load media library')
     } finally {
       setIsLoading(false)
     }
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    setActiveTab('library')
+    setLinkValue('')
+    setPrompt('')
+    setGenError('')
+    setResultBase64('')
+    setResultMime('image/png')
+    setFilename('openshop-image.png')
+    setFiles([])
+    setDriveError('')
+    loadLibrary()
+    checkDriveStatus()
+  }, [open, loadLibrary, checkDriveStatus, setDriveError])
+
+  const combinedError = error || driveError
+
+  function handleTabChange(tab) {
+    setActiveTab(tab)
+    setError('')
+    setDriveError('')
+    setGenError('')
   }
 
   function handlePick(url) {
@@ -87,41 +103,14 @@ export default function MediaPickerModal({ open, onClose, onPick }) {
     onClose?.()
   }
 
-  function renderTabs() {
-    const TabBtn = ({ id, children }) => (
-      <button
-        type="button"
-        className={`px-3 py-1.5 text-sm rounded border ${activeTab === id ? 'bg-gray-900 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
-        onClick={() => setActiveTab(id)}
-      >{children}</button>
-    )
-    return (
-      <div className="flex items-center gap-2">
-        <TabBtn id="library">Library</TabBtn>
-        <TabBtn id="link">Link</TabBtn>
-        <TabBtn id="generate">Generate</TabBtn>
-      </div>
-    )
-  }
-
   function renderLibrary() {
     if (isLoading) return <p className="text-sm text-gray-500">Loading…</p>
-    if (error) return <p className="text-sm text-red-600">{error}</p>
-    if (!library.length) return <p className="text-sm text-gray-500">No media found yet. Try Link or Generate.</p>
     return (
-      <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 max-h-80 overflow-auto">
-        {library.map((url, i) => (
-          <button
-            key={i}
-            type="button"
-            className="aspect-square rounded border overflow-hidden bg-white hover:ring-2 hover:ring-purple-500"
-            title={url}
-            onClick={() => handlePick(url)}
-          >
-            <img src={normalizeImageUrl(url)} alt="media" className="w-full h-full object-cover" />
-          </button>
-        ))}
-      </div>
+      <MediaGrid
+        items={library}
+        onSelect={handlePick}
+        emptyMessage="No media found yet. Try Link or Generate."
+      />
     )
   }
 
@@ -129,82 +118,44 @@ export default function MediaPickerModal({ open, onClose, onPick }) {
     return (
       <div className="space-y-2">
         <label className="block text-sm font-medium">Paste image URL</label>
-        <Input value={linkValue} onChange={(e) => setLinkValue(e.target.value)} placeholder="https://…" />
+        <Input value={linkValue} onChange={(event) => setLinkValue(event.target.value)} placeholder="https://…" />
         <div className="flex justify-end">
-          <Button type="button" onClick={() => linkValue && handlePick(linkValue)}>Use image URL</Button>
+          <Button type="button" onClick={() => linkValue && handlePick(linkValue)}>
+            Use image URL
+          </Button>
         </div>
       </div>
     )
   }
 
-  async function checkDriveStatus() {
-    try {
-      const res = await adminApiRequest('/api/admin/drive/status', { method: 'GET' })
-      const data = await res.json()
-      setDriveConnected(!!data.connected)
-    } catch (_) {
-      setDriveConnected(false)
-    }
-  }
-
-  async function handleDriveDisconnect() {
-    try {
-      const res = await adminApiRequest('/api/admin/drive/disconnect', { method: 'POST' })
-      if (res.ok) {
-        setDriveConnected(false)
-      } else {
-        throw new Error('Failed to disconnect')
-      }
-    } catch (e) {
-      console.error('Failed to disconnect Google Drive:', e)
-    }
-  }
-
-  function updateSlotFile(slotIndex, fileOrNull) {
-    setFiles(prev => {
+  const handleSlotChange = (index, file) => {
+    setFiles((prev) => {
       const next = [...prev]
-      next[slotIndex] = fileOrNull || null
-      let last = -1
-      for (let i = 0; i < next.length; i++) if (next[i]) last = i
-      return last >= 0 ? next.slice(0, Math.max(last + 1, 4)) : Array(0)
+      next[index] = file || null
+      let lastIndex = -1
+      for (let i = 0; i < next.length; i += 1) {
+        if (next[i]) lastIndex = i
+      }
+      return lastIndex >= 0 ? next.slice(0, Math.max(lastIndex + 1, 4)) : []
     })
-  }
-
-  async function fileToDataUrl(file) {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(reader.result)
-      reader.onerror = reject
-      reader.readAsDataURL(file)
-    })
-  }
-
-  function parseDataUrl(dataUrl) {
-    const match = String(dataUrl).match(/^data:([^;]+);base64,(.*)$/)
-    if (!match) return { mimeType: 'application/octet-stream', base64: '' }
-    return { mimeType: match[1], base64: match[2] }
-  }
-
-  function dataUrlFromState() {
-    if (!resultBase64) return ''
-    return `data:${resultMime};base64,${resultBase64}`
   }
 
   async function handleGenerate() {
+    if (!prompt) return
     setGenError('')
     setIsGenerating(true)
     setResultBase64('')
     try {
       const inputs = []
-      for (const f of files.slice(0, 4)) {
-        if (!f) continue
-        const dataUrl = await fileToDataUrl(f)
+      for (const file of files) {
+        if (!file) continue
+        const dataUrl = await fileToDataUrl(file)
         const { mimeType, base64 } = parseDataUrl(dataUrl)
         inputs.push({ mimeType, dataBase64: base64 })
       }
       const res = await adminApiRequest('/api/admin/ai/generate-image', {
         method: 'POST',
-        body: JSON.stringify({ prompt, inputs })
+        body: JSON.stringify({ prompt, inputs }),
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
@@ -215,8 +166,8 @@ export default function MediaPickerModal({ open, onClose, onPick }) {
       setResultMime(data.mimeType || 'image/png')
       const ext = (data.mimeType || 'image/png').split('/')[1] || 'png'
       setFilename(`openshop-image.${ext}`)
-    } catch (e) {
-      setGenError(String(e.message || e))
+    } catch (err) {
+      setGenError(err.message || 'Generation failed')
     } finally {
       setIsGenerating(false)
     }
@@ -232,35 +183,17 @@ export default function MediaPickerModal({ open, onClose, onPick }) {
         body: JSON.stringify({
           mimeType: resultMime,
           dataBase64: resultBase64,
-          filename: filename || 'openshop-image.png'
-        })
+          filename: filename || 'openshop-image.png',
+        }),
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Upload failed')
       handlePick(data.viewUrl || data.webViewLink || data.downloadUrl)
-    } catch (e) {
-      setGenError(String(e.message || e))
+    } catch (err) {
+      setGenError(err.message || 'Upload failed')
     } finally {
       setIsUploading(false)
     }
-  }
-
-  function renderSlot(i) {
-    const file = files[i] || null
-    const has = !!file
-    return (
-      <label key={i} className="aspect-square border rounded-md flex items-center justify-center cursor-pointer bg-gray-50 hover:bg-gray-100 overflow-hidden">
-        <input type="file" accept="image/*" className="hidden" onChange={(e) => updateSlotFile(i, e.target.files && e.target.files[0] ? e.target.files[0] : null)} />
-        {has ? (
-          <SlotPreview file={file} onClear={() => updateSlotFile(i, null)} />
-        ) : (
-          <div className="flex flex-col items-center text-gray-500 text-sm">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
-            <span className="mt-1">Add</span>
-          </div>
-        )}
-      </label>
-    )
   }
 
   function renderGenerate() {
@@ -268,13 +201,15 @@ export default function MediaPickerModal({ open, onClose, onPick }) {
       <div className="space-y-4">
         <div>
           <label className="block text-sm font-medium mb-1">Prompt</label>
-          <Input value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="Describe what to create or edit..." />
+          <Input
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            placeholder="Describe what to create or edit..."
+          />
         </div>
         <div>
           <label className="block text-sm font-medium mb-2">Reference images (up to 4)</label>
-          <div className="grid grid-cols-4 gap-2">
-            {Array.from({ length: 4 }).map((_, i) => renderSlot(i))}
-          </div>
+          <ReferenceSlots files={files} onChange={handleSlotChange} slots={4} />
         </div>
         <div className="flex items-center gap-2">
           <Button type="button" onClick={handleGenerate} disabled={isGenerating || !prompt}>
@@ -284,21 +219,36 @@ export default function MediaPickerModal({ open, onClose, onPick }) {
         </div>
         {resultBase64 && (
           <div className="mt-2">
-            <img src={dataUrlFromState()} alt="generated" className="w-1/2 h-auto rounded border" />
+            <img
+              src={buildDataUrl({ mimeType: resultMime, base64: resultBase64 })}
+              alt="generated"
+              className="w-1/2 h-auto rounded border"
+            />
             <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-2 items-end">
               <div>
                 <label className="block text-sm font-medium mb-1">Filename</label>
-                <Input value={filename} onChange={(e) => setFilename(e.target.value)} />
+                <Input value={filename} onChange={(event) => setFilename(event.target.value)} />
               </div>
               <div className="flex gap-2 justify-end">
-                <Button type="button" variant="outline" onClick={() => handlePick(dataUrlFromState())}>Use data URL</Button>
+                <Button type="button" variant="outline" onClick={() => handlePick(buildDataUrl({ mimeType: resultMime, base64: resultBase64 }))}>
+                  Use data URL
+                </Button>
                 {driveConnected ? (
                   <div className="flex items-center gap-2">
-                    <Button type="button" onClick={uploadToDrive} disabled={isUploading}>{isUploading ? 'Uploading…' : 'Upload to Drive'}</Button>
-                    <Button type="button" variant="outline" size="sm" onClick={handleDriveDisconnect}>Disconnect</Button>
+                    <Button type="button" onClick={uploadToDrive} disabled={isUploading}>
+                      {isUploading ? 'Uploading…' : 'Upload to Drive'}
+                    </Button>
+                    <Button type="button" variant="outline" size="sm" onClick={disconnectDrive}>
+                      Disconnect
+                    </Button>
                   </div>
                 ) : (
-                  <Button type="button" onClick={() => window.open('/api/admin/drive/oauth/start', '_blank', 'width=480,height=720')}>Connect Google Drive</Button>
+                  <Button
+                    type="button"
+                    onClick={() => window.open('/api/admin/drive/oauth/start', '_blank', 'width=480,height=720')}
+                  >
+                    Connect Google Drive
+                  </Button>
                 )}
               </div>
             </div>
@@ -308,41 +258,24 @@ export default function MediaPickerModal({ open, onClose, onPick }) {
     )
   }
 
-  if (!open) return null
-
   return (
-    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50" onClick={onClose}>
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-3xl mx-4 flex flex-col max-h-[80vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
-        <div className="p-4 border-b flex items-center justify-between flex-shrink-0">
-          <h3 className="text-lg font-semibold">Choose an image</h3>
-          {renderTabs()}
-        </div>
-        <div className="p-4 flex-1 overflow-y-auto">
-          {activeTab === 'library' && renderLibrary()}
-          {activeTab === 'link' && renderLink()}
-          {activeTab === 'generate' && renderGenerate()}
-        </div>
-        <div className="p-3 border-t flex justify-end flex-shrink-0">
-          <Button type="button" variant="outline" onClick={onClose}>Close</Button>
-        </div>
+    <MediaModalLayout
+      open={open}
+      title="Choose an image"
+      onClose={onClose}
+      footer={
+        <Button type="button" variant="outline" onClick={onClose}>
+          Close
+        </Button>
+      }
+    >
+      {combinedError && <p className="text-sm text-red-600 mb-2">{combinedError}</p>}
+      <MediaTabs tabs={TABS} activeTab={activeTab} onTabChange={handleTabChange} />
+      <div className="mt-4">
+        {activeTab === 'library' && renderLibrary()}
+        {activeTab === 'link' && renderLink()}
+        {activeTab === 'generate' && renderGenerate()}
       </div>
-    </div>
+    </MediaModalLayout>
   )
 }
-
-function SlotPreview({ file, onClear }) {
-  const [src, setSrc] = useState('')
-  useEffect(() => {
-    const url = URL.createObjectURL(file)
-    setSrc(url)
-    return () => URL.revokeObjectURL(url)
-  }, [file])
-  return (
-    <div className="relative w-full h-full">
-      <img src={src} alt="preview" className="absolute inset-0 w-full h-full object-cover" />
-      <button type="button" onClick={(e) => { e.preventDefault(); onClear?.() }} className="absolute top-1 right-1 bg-white/80 hover:bg-white text-gray-700 rounded px-2 py-0.5 text-xs border">Clear</button>
-    </div>
-  )
-}
-
-

--- a/src/components/admin/ProductForm.jsx
+++ b/src/components/admin/ProductForm.jsx
@@ -1,22 +1,24 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Card, CardHeader, CardTitle, CardContent } from '../ui/card'
 import { Input } from '../ui/input'
 import { Textarea } from '../ui/textarea'
 import { Button } from '../ui/button'
 import { Select } from '../ui/select'
-import { generateId, normalizeImageUrl } from '../../lib/utils'
-import ImageUrlField from './ImageUrlField'
-import { 
+import { generateId } from '../../lib/utils'
+import {
   AlertDialog,
   AlertDialogContent,
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogDescription,
   AlertDialogFooter,
-  AlertDialogAction
+  AlertDialogAction,
 } from '../ui/alert-dialog'
 import { Switch } from '../ui/switch'
 import { adminApiRequest } from '../../lib/auth'
+import VariantGroup from './product-form/VariantGroup'
+import ProductImageFields from './product-form/ProductImageFields'
+import { useDriveImageNormalizer } from './product-form/useDriveImageNormalizer'
 
 export function ProductForm({ product, onSave, onCancel }) {
   const [formData, setFormData] = useState({
@@ -33,7 +35,7 @@ export function ProductForm({ product, onSave, onCancel }) {
     variants: [],
     variantStyle2: '',
     variants2: [],
-    archived: false
+    archived: false,
   })
   const [enableVariants1, setEnableVariants1] = useState(false)
   const [enableVariants2, setEnableVariants2] = useState(false)
@@ -42,21 +44,23 @@ export function ProductForm({ product, onSave, onCancel }) {
   const [errorOpen, setErrorOpen] = useState(false)
   const [errorText, setErrorText] = useState('')
   const [loading, setLoading] = useState(false)
-  const [driveNotice, setDriveNotice] = useState('')
-  const [driveNoticeTimer, setDriveNoticeTimer] = useState(null)
+  const { normalize, notice: driveNotice } = useDriveImageNormalizer()
 
   useEffect(() => {
     if (product) {
       setFormData({
         ...product,
         tagline: product.tagline || product.description || '',
-        images: Array.isArray(product.images) ? product.images : 
-               (product.imageUrl ? [product.imageUrl] : [''])
+        images: Array.isArray(product.images)
+          ? product.images
+          : product.imageUrl
+            ? [product.imageUrl]
+            : [''],
       })
       setEnableVariants1(!!(product.variants && product.variants.length > 0 || product.variantStyle))
       setEnableVariants2(!!(product.variants2 && product.variants2.length > 0 || product.variantStyle2))
     } else {
-      setFormData(prev => ({ ...prev, id: generateId() }))
+      setFormData((prev) => ({ ...prev, id: generateId() }))
       setEnableVariants1(false)
       setEnableVariants2(false)
     }
@@ -75,132 +79,79 @@ export function ProductForm({ product, onSave, onCancel }) {
     }
   }
 
-  const handleChange = (e) => {
-    const { name, value } = e.target
-    setFormData(prev => ({
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setFormData((prev) => ({
       ...prev,
-      [name]: value
+      [name]: value,
     }))
   }
 
   const handleImageChange = (index, value) => {
-    const normalized = maybeNormalizeDriveUrl(value)
-    setFormData(prev => ({
+    const normalized = normalize(value)
+    setFormData((prev) => ({
       ...prev,
-      images: prev.images.map((img, i) => i === index ? normalized : img)
+      images: prev.images.map((img, i) => (i === index ? normalized : img)),
     }))
   }
 
   const addImageField = () => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      images: [...prev.images, '']
-    }))
-  }
-
-  const addVariant = () => {
-    setFormData(prev => ({
-      ...prev,
-      variants: [...(prev.variants || []), { id: generateId(), name: '', selectorImageUrl: '', displayImageUrl: '', hasCustomPrice: false, price: '' }]
-    }))
-  }
-
-  const addVariant2 = () => {
-    setFormData(prev => ({
-      ...prev,
-      variants2: [...(prev.variants2 || []), { id: generateId(), name: '', selectorImageUrl: '', displayImageUrl: '', hasCustomPrice: false, price: '' }]
-    }))
-  }
-
-  const updateVariant = (index, key, value) => {
-    const newVal = (key === 'selectorImageUrl' || key === 'displayImageUrl')
-      ? maybeNormalizeDriveUrl(value)
-      : value
-    setFormData(prev => ({
-      ...prev,
-      variants: (prev.variants || []).map((v, i) => i === index ? { ...v, [key]: newVal } : v)
-    }))
-  }
-
-  const updateVariant2 = (index, key, value) => {
-    const newVal = (key === 'selectorImageUrl' || key === 'displayImageUrl')
-      ? maybeNormalizeDriveUrl(value)
-      : value
-    setFormData(prev => ({
-      ...prev,
-      variants2: (prev.variants2 || []).map((v, i) => i === index ? { ...v, [key]: newVal } : v)
-    }))
-  }
-
-  function maybeNormalizeDriveUrl(input) {
-    const val = (input || '').trim()
-    if (!val) return input
-    const isDrive = val.includes('drive.google.com') || val.includes('drive.usercontent.google.com')
-    if (!isDrive) return input
-    // Extract file id
-    const fileMatch = val.match(/\/file\/d\/([a-zA-Z0-9_-]+)/)
-    const idMatch = val.match(/[?&#]id=([a-zA-Z0-9_-]+)/)
-    const id = (fileMatch && fileMatch[1]) || (idMatch && idMatch[1]) || null
-    const normalized = id
-      ? `https://drive.usercontent.google.com/download?id=${id}&export=view`
-      : val
-    if (normalized !== val) {
-      setDriveNotice('Google Drive link detected — converted for reliable preview and delivery.')
-      if (driveNoticeTimer) clearTimeout(driveNoticeTimer)
-      const t = setTimeout(() => setDriveNotice(''), 3000)
-      setDriveNoticeTimer(t)
-    }
-    return normalized
-  }
-
-  const removeVariant = (index) => {
-    setFormData(prev => ({
-      ...prev,
-      variants: (prev.variants || []).filter((_, i) => i !== index)
-    }))
-  }
-
-  const removeVariant2 = (index) => {
-    setFormData(prev => ({
-      ...prev,
-      variants2: (prev.variants2 || []).filter((_, i) => i !== index)
+      images: [...prev.images, ''],
     }))
   }
 
   const removeImageField = (index) => {
-    if (formData.images.length > 1) {
-      setFormData(prev => ({
-        ...prev,
-        images: prev.images.filter((_, i) => i !== index)
-      }))
-    }
+    setFormData((prev) => ({
+      ...prev,
+      images: prev.images.filter((_, i) => i !== index),
+    }))
   }
 
-  const handleSubmit = async (e) => {
-    e.preventDefault()
+  const addVariant = () => {
+    setFormData((prev) => ({
+      ...prev,
+      variants: [...(prev.variants || []), emptyVariant()],
+    }))
+  }
+
+  const addVariant2 = () => {
+    setFormData((prev) => ({
+      ...prev,
+      variants2: [...(prev.variants2 || []), emptyVariant()],
+    }))
+  }
+
+  const updateVariantList = (key, index, field, value) => {
+    const normalizedValue =
+      field === 'selectorImageUrl' || field === 'displayImageUrl' ? normalize(value) : value
+    setFormData((prev) => ({
+      ...prev,
+      [key]: (prev[key] || []).map((variant, i) =>
+        i === index ? { ...variant, [field]: normalizedValue } : variant,
+      ),
+    }))
+  }
+
+  const removeVariantFromList = (key, index) => {
+    setFormData((prev) => ({
+      ...prev,
+      [key]: (prev[key] || []).filter((_, i) => i !== index),
+    }))
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
     setLoading(true)
 
     try {
       const productData = {
         ...formData,
         price: parseFloat(formData.price),
-        images: formData.images.filter(img => img.trim() !== ''),
-        variants: (formData.variants || []).map(v => ({ 
-          id: v.id || generateId(), 
-          name: v.name, 
-          selectorImageUrl: v.selectorImageUrl || v.imageUrl || v.displayImageUrl || '',
-          displayImageUrl: v.displayImageUrl || v.imageUrl || v.selectorImageUrl || '',
-          hasCustomPrice: !!v.hasCustomPrice,
-          price: v.hasCustomPrice ? parseFloat(v.price || '0') : undefined,
-        })),
-        variants2: (formData.variants2 || []).map(v => ({
-          id: v.id || generateId(),
-          name: v.name,
-          selectorImageUrl: v.selectorImageUrl || v.imageUrl || v.displayImageUrl || '',
-          displayImageUrl: v.displayImageUrl || v.imageUrl || v.selectorImageUrl || '',
-          hasCustomPrice: !!v.hasCustomPrice,
-          price: v.hasCustomPrice ? parseFloat(v.price || '0') : undefined,
-        })),
+        images: formData.images.filter((img) => img.trim() !== ''),
+        variants: prepareVariants(formData.variants || []),
+        variants2: prepareVariants(formData.variants2 || []),
       }
 
       const url = product ? `/api/admin/products/${product.id}` : '/api/admin/products'
@@ -228,358 +179,229 @@ export function ProductForm({ product, onSave, onCancel }) {
 
   return (
     <>
-    <Card className="w-full max-w-2xl">
-      <CardHeader>
-        <CardTitle>
-          {product ? 'Edit Product' : 'Create New Product'}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="p-6">
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <div>
-            <label className="block text-sm font-medium mb-2">Product Name *</label>
-            <Input
-              name="name"
-              value={formData.name}
-              onChange={handleChange}
-              placeholder="Enter product name"
-              required
-            />
-          </div>
-
-          <div className="flex items-center gap-3">
-            <Switch
-              id="archived"
-              checked={!!formData.archived}
-              onCheckedChange={(v) => setFormData(prev => ({ ...prev, archived: v }))}
-            />
-            <label htmlFor="archived" className="text-sm text-gray-700 select-none">Archived (hide from storefront)</label>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium mb-2">Tagline (short)</label>
-            <Input
-              name="tagline"
-              value={formData.tagline}
-              onChange={handleChange}
-              placeholder="A short one-liner for cards"
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium mb-2">Description (detailed)</label>
-            <Textarea
-              name="description"
-              value={formData.description}
-              onChange={handleChange}
-              placeholder="Enter a multi-sentence product description for the PDP"
-              rows={3}
-            />
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
+      <Card className="w-full max-w-2xl">
+        <CardHeader>
+          <CardTitle>{product ? 'Edit Product' : 'Create New Product'}</CardTitle>
+        </CardHeader>
+        <CardContent className="p-6">
+          <form onSubmit={handleSubmit} className="space-y-3">
             <div>
-              <label className="block text-sm font-medium mb-2">Price *</label>
+              <label className="block text-sm font-medium mb-2">Product Name *</label>
               <Input
-                name="price"
-                type="number"
-                step="0.01"
-                min="0"
-                value={formData.price}
+                name="name"
+                value={formData.name}
                 onChange={handleChange}
-                placeholder="0.00"
+                placeholder="Enter product name"
                 required
               />
             </div>
+
+            <div className="flex items-center gap-3">
+              <Switch
+                id="archived"
+                checked={!!formData.archived}
+                onCheckedChange={(value) =>
+                  setFormData((prev) => ({ ...prev, archived: value }))
+                }
+              />
+              <label htmlFor="archived" className="text-sm text-gray-700 select-none">
+                Archived (hide from storefront)
+              </label>
+            </div>
+
             <div>
-              <label className="block text-sm font-medium mb-2">Currency</label>
-              <Select
-                name="currency"
-                value={formData.currency}
+              <label className="block text-sm font-medium mb-2">Tagline (short)</label>
+              <Input
+                name="tagline"
+                value={formData.tagline}
                 onChange={handleChange}
-              >
-                <option value="usd">USD</option>
-                <option value="eur">EUR</option>
-                <option value="gbp">GBP</option>
+                placeholder="A short one-liner for cards"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-2">Description (detailed)</label>
+              <Textarea
+                name="description"
+                value={formData.description}
+                onChange={handleChange}
+                placeholder="Enter a multi-sentence product description for the PDP"
+                rows={3}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-2">Price *</label>
+                <Input
+                  name="price"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={formData.price}
+                  onChange={handleChange}
+                  placeholder="0.00"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-2">Currency</label>
+                <Select name="currency" value={formData.currency} onChange={handleChange}>
+                  <option value="usd">USD</option>
+                  <option value="eur">EUR</option>
+                  <option value="gbp">GBP</option>
+                </Select>
+              </div>
+            </div>
+
+            <ProductImageFields
+              images={formData.images}
+              onImageChange={handleImageChange}
+              onAddImage={addImageField}
+              onRemoveImage={removeImageField}
+              onPreviewImage={setModalImage}
+              notice={driveNotice}
+            />
+
+            <div>
+              <label className="block text-sm font-medium mb-2">Collection</label>
+              <Select name="collectionId" value={formData.collectionId} onChange={handleChange}>
+                <option value="">Select a collection</option>
+                {collections.map((collection) => (
+                  <option key={collection.id} value={collection.id}>
+                    {collection.name}
+                  </option>
+                ))}
               </Select>
             </div>
-          </div>
 
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <label className="block text-sm font-medium">Product Images</label>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={addImageField}
-              >
-                Add Image
+            <VariantGroup
+              id="enableVariants1"
+              enabled={enableVariants1}
+              onToggle={setEnableVariants1}
+              title="Variants"
+              description="Enable Variant Group 1"
+              styleLabel="Variant Style (e.g., Color, Logo)"
+              styleValue={formData.variantStyle || ''}
+              onStyleChange={(value) =>
+                setFormData((prev) => ({ ...prev, variantStyle: value }))
+              }
+              stylePlaceholder="Color"
+              variants={formData.variants || []}
+              onAddVariant={addVariant}
+              onVariantChange={(index, field, value) =>
+                updateVariantList('variants', index, field, value)
+              }
+              onVariantRemove={(index) => removeVariantFromList('variants', index)}
+              emptyMessage="No variants added. Add at least one to enable variant selection on the PDP."
+              priceLabel="Custom price for this variant"
+              namePlaceholder="Variant name (e.g., Green)"
+              onPreviewImage={setModalImage}
+            />
+
+            <VariantGroup
+              id="enableVariants2"
+              enabled={enableVariants2}
+              onToggle={setEnableVariants2}
+              title="Second Variant Group (optional)"
+              description="Enable Variant Group 2"
+              styleLabel="Variant Style (e.g., Size)"
+              styleValue={formData.variantStyle2 || ''}
+              onStyleChange={(value) =>
+                setFormData((prev) => ({ ...prev, variantStyle2: value }))
+              }
+              stylePlaceholder="Size"
+              variants={formData.variants2 || []}
+              onAddVariant={addVariant2}
+              onVariantChange={(index, field, value) =>
+                updateVariantList('variants2', index, field, value)
+              }
+              onVariantRemove={(index) => removeVariantFromList('variants2', index)}
+              emptyMessage="No options added."
+              priceLabel="Custom price for this option"
+              namePlaceholder="Variant name (e.g., Large)"
+              onPreviewImage={setModalImage}
+            />
+
+            <div className="flex gap-4 pt-4">
+              <Button type="submit" disabled={loading}>
+                {loading ? 'Saving...' : product ? 'Update Product' : 'Create Product'}
+              </Button>
+              <Button type="button" variant="outline" onClick={onCancel}>
+                Cancel
               </Button>
             </div>
-            <div className="space-y-2">
-              {formData.images.map((image, index) => (
-                <ImageUrlField
-                  key={index}
-                  value={image}
-                  onChange={(val) => handleImageChange(index, val)}
-                  placeholder={`Image URL ${index + 1}`}
-                  onPreview={(src) => setModalImage(src)}
-                  onRemove={formData.images.length > 1 ? () => removeImageField(index) : undefined}
-                  hideInput
-                />
-              ))}
-            </div>
-            {driveNotice && (
-              <p className="text-xs text-purple-700 mt-2">{driveNotice}</p>
-            )}
-            <p className="text-sm text-gray-500 mt-1">
-              Add multiple images for your product. The first image will be the primary image.
-            </p>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium mb-2">Collection</label>
-            <Select
-              name="collectionId"
-              value={formData.collectionId}
-              onChange={handleChange}
-            >
-              <option value="">Select a collection</option>
-              {collections.map((collection) => (
-                <option key={collection.id} value={collection.id}>
-                  {collection.name}
-                </option>
-              ))}
-            </Select>
-          </div>
-
-          {/* Variants */}
-          <div className="space-y-3">
-            <div className="flex items-center gap-3">
-              <Switch id="enableVariants1" checked={enableVariants1} onCheckedChange={setEnableVariants1} />
-              <label htmlFor="enableVariants1" className="text-sm text-gray-700 select-none">Enable Variant Group 1</label>
-            </div>
-            {enableVariants1 && (
-              <>
-                <h3 className="text-lg font-medium text-gray-900">Variants</h3>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Variant Style (e.g., Color, Logo)</label>
-                  <Input
-                    name="variantStyle"
-                    value={formData.variantStyle || ''}
-                    onChange={handleChange}
-                    placeholder="Color"
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <label className="block text-sm font-medium">Variant Picker</label>
-                  <Button type="button" variant="outline" size="sm" onClick={addVariant}>Add Variant</Button>
-                </div>
-                <div className="grid grid-cols-12 gap-2 text-xs text-gray-600 px-1">
-                  <div className="col-span-3">Variant name</div>
-                  <div className="col-span-4">Selector image</div>
-                  <div className="col-span-4">Display image</div>
-                </div>
-                {(formData.variants || []).length === 0 ? (
-                  <p className="text-sm text-gray-500">No variants added. Add at least one to enable variant selection on the PDP.</p>
-                ) : (
-                  <div className="space-y-2">
-                    {(formData.variants || []).map((variant, index) => (
-                      <div key={variant.id || index} className="grid grid-cols-12 gap-2 items-center">
-                        <div className="col-span-3">
-                          <Input
-                            value={variant.name}
-                            onChange={(e) => updateVariant(index, 'name', e.target.value)}
-                            placeholder="Variant name (e.g., Green)"
-                          />
-                        </div>
-                        <div className="col-span-4">
-                          <div className="flex items-center gap-2">
-                            <ImageUrlField
-                              value={variant.selectorImageUrl || ''}
-                              onChange={(val) => updateVariant(index, 'selectorImageUrl', val)}
-                              placeholder="Selector image URL"
-                              onPreview={(src) => setModalImage(src)}
-                              hideInput
-                            />
-                          </div>
-                        </div>
-                        <div className="col-span-4">
-                          <div className="flex items-center gap-2">
-                            <ImageUrlField
-                              value={variant.displayImageUrl || ''}
-                              onChange={(val) => updateVariant(index, 'displayImageUrl', val)}
-                              placeholder="Display image URL"
-                              onPreview={(src) => setModalImage(src)}
-                              hideInput
-                            />
-                          </div>
-                        </div>
-                        <div className="col-span-12 grid grid-cols-12 gap-2 items-center">
-                          <label className="col-span-3 flex items-center gap-2 text-sm text-gray-700">
-                            <Switch
-                              checked={!!variant.hasCustomPrice}
-                              onCheckedChange={(v) => updateVariant(index, 'hasCustomPrice', v)}
-                            />
-                            Custom price for this variant
-                          </label>
-                          <div className="col-span-3">
-                            <Input
-                              type="number"
-                              step="0.01"
-                              min="0"
-                              disabled={!variant.hasCustomPrice}
-                              value={variant.price ?? ''}
-                              onChange={(e) => updateVariant(index, 'price', e.target.value)}
-                              placeholder="Variant price"
-                            />
-                          </div>
-                        </div>
-                        <div className="col-span-1 text-right">
-                          <Button type="button" variant="outline" size="sm" className="px-3" onClick={() => removeVariant(index)}>×</Button>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-
-          {/* Secondary Variants */}
-          <div className="space-y-3">
-            <div className="flex items-center gap-3">
-              <Switch id="enableVariants2" checked={enableVariants2} onCheckedChange={setEnableVariants2} />
-              <label htmlFor="enableVariants2" className="text-sm text-gray-700 select-none">Enable Variant Group 2</label>
-            </div>
-            {enableVariants2 && (
-              <>
-                <h3 className="text-lg font-medium text-gray-900">Second Variant Group (optional)</h3>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Variant Style (e.g., Size)</label>
-                  <Input
-                    name="variantStyle2"
-                    value={formData.variantStyle2 || ''}
-                    onChange={handleChange}
-                    placeholder="Size"
-                  />
-                </div>
-                <div className="flex items-center justify-between">
-                  <label className="block text-sm font-medium">Variant Picker</label>
-                  <Button type="button" variant="outline" size="sm" onClick={addVariant2}>Add Variant</Button>
-                </div>
-                <div className="grid grid-cols-12 gap-2 text-xs text-gray-600 px-1">
-                  <div className="col-span-3">Option name</div>
-                  <div className="col-span-4">Selector image</div>
-                  <div className="col-span-4">Display image</div>
-                </div>
-                {(formData.variants2 || []).length === 0 ? (
-                  <p className="text-sm text-gray-500">No options added.</p>
-                ) : (
-                  <div className="space-y-2">
-                    {(formData.variants2 || []).map((variant, index) => (
-                      <div key={variant.id || index} className="grid grid-cols-12 gap-2 items-center">
-                        <div className="col-span-3">
-                          <Input
-                            value={variant.name}
-                            onChange={(e) => updateVariant2(index, 'name', e.target.value)}
-                            placeholder="Variant name (e.g., Large)"
-                          />
-                        </div>
-                        <div className="col-span-4">
-                          <div className="flex items-center gap-2">
-                            <ImageUrlField
-                              value={variant.selectorImageUrl || ''}
-                              onChange={(val) => updateVariant2(index, 'selectorImageUrl', val)}
-                              placeholder="Selector image URL"
-                              onPreview={(src) => setModalImage(src)}
-                              hideInput
-                            />
-                          </div>
-                        </div>
-                        <div className="col-span-4">
-                          <div className="flex items-center gap-2">
-                            <ImageUrlField
-                              value={variant.displayImageUrl || ''}
-                              onChange={(val) => updateVariant2(index, 'displayImageUrl', val)}
-                              placeholder="Display image URL"
-                              onPreview={(src) => setModalImage(src)}
-                              hideInput
-                            />
-                          </div>
-                        </div>
-                        <div className="col-span-12 grid grid-cols-12 gap-2 items-center">
-                          <label className="col-span-3 flex items-center gap-2 text-sm text-gray-700">
-                            <Switch
-                              checked={!!variant.hasCustomPrice}
-                              onCheckedChange={(v) => updateVariant2(index, 'hasCustomPrice', v)}
-                            />
-                            Custom price for this option
-                          </label>
-                          <div className="col-span-3">
-                            <Input
-                              type="number"
-                              step="0.01"
-                              min="0"
-                              disabled={!variant.hasCustomPrice}
-                              value={variant.price ?? ''}
-                              onChange={(e) => updateVariant2(index, 'price', e.target.value)}
-                              placeholder="Option price"
-                            />
-                          </div>
-                        </div>
-                        <div className="col-span-1 text-right">
-                          <Button type="button" variant="outline" size="sm" className="px-3" onClick={() => removeVariant2(index)}>×</Button>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-
-          <div className="flex gap-4 pt-4">
-            <Button type="submit" disabled={loading}>
-              {loading ? 'Saving...' : (product ? 'Update Product' : 'Create Product')}
-            </Button>
-            <Button type="button" variant="outline" onClick={onCancel}>
-              Cancel
-            </Button>
-          </div>
-        </form>
-      </CardContent>
-    </Card>
-    {modalImage && (
-      <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50" onClick={() => setModalImage(null)}>
-        <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full mx-4 relative max-h-[90vh] overflow-auto" onClick={(e) => e.stopPropagation()}>
-          <button
-            type="button"
-            className="absolute top-2 right-2 px-2 py-1 rounded border bg-white/90 hover:bg-white"
-            onClick={() => setModalImage(null)}
-            aria-label="Close"
+          </form>
+        </CardContent>
+      </Card>
+      {modalImage && (
+        <div
+          className="fixed inset-0 bg-black/70 flex items-center justify-center z-50"
+          onClick={() => setModalImage(null)}
+        >
+          <div
+            className="bg-white rounded-lg shadow-xl max-w-3xl w-full mx-4 relative max-h-[90vh] overflow-auto"
+            onClick={(event) => event.stopPropagation()}
           >
-            ×
-          </button>
-          <img src={modalImage} alt="preview" className="w-full h-auto max-h-[80vh] object-contain rounded" />
-          <div className="p-3 border-t text-center">
-            <a href={modalImage} target="_blank" rel="noreferrer" className="text-sm text-purple-600 hover:text-purple-700">Open original</a>
+            <button
+              type="button"
+              className="absolute top-2 right-2 px-2 py-1 rounded border bg-white/90 hover:bg-white"
+              onClick={() => setModalImage(null)}
+              aria-label="Close"
+            >
+              ×
+            </button>
+            <img
+              src={modalImage}
+              alt="preview"
+              className="w-full h-auto max-h-[80vh] object-contain rounded"
+            />
+            <div className="p-3 border-t text-center">
+              <a
+                href={modalImage}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-purple-600 hover:text-purple-700"
+              >
+                Open original
+              </a>
+            </div>
           </div>
         </div>
-      </div>
-    )}
-    <AlertDialog open={errorOpen} onOpenChange={setErrorOpen}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Something went wrong</AlertDialogTitle>
-          <AlertDialogDescription>{errorText}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogAction>OK</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+      )}
+      <AlertDialog open={errorOpen} onOpenChange={setErrorOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Something went wrong</AlertDialogTitle>
+            <AlertDialogDescription>{errorText}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction>OK</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
+}
+
+function emptyVariant() {
+  return {
+    id: generateId(),
+    name: '',
+    selectorImageUrl: '',
+    displayImageUrl: '',
+    hasCustomPrice: false,
+    price: '',
+  }
+}
+
+function prepareVariants(list) {
+  return list.map((variant) => ({
+    id: variant.id || generateId(),
+    name: variant.name,
+    selectorImageUrl: variant.selectorImageUrl || variant.imageUrl || variant.displayImageUrl || '',
+    displayImageUrl: variant.displayImageUrl || variant.imageUrl || variant.selectorImageUrl || '',
+    hasCustomPrice: !!variant.hasCustomPrice,
+    price: variant.hasCustomPrice ? parseFloat(variant.price || '0') : undefined,
+  }))
 }

--- a/src/components/admin/media/MediaGrid.jsx
+++ b/src/components/admin/media/MediaGrid.jsx
@@ -1,0 +1,28 @@
+import { normalizeImageUrl } from '../../../lib/utils'
+
+export default function MediaGrid({ items = [], onSelect, emptyMessage }) {
+  if (!items.length) {
+    return <p className="text-sm text-gray-500">{emptyMessage}</p>
+  }
+
+  return (
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
+      {items.map((item, index) => {
+        const url = typeof item === 'string' ? item : item.url
+        const key = item.id ?? index
+        const title = typeof item === 'string' ? item : item.filename || item.url
+        return (
+          <button
+            key={key}
+            type="button"
+            className="aspect-square rounded border overflow-hidden bg-white hover:ring-2 hover:ring-purple-500"
+            title={title}
+            onClick={() => onSelect(url)}
+          >
+            <img src={normalizeImageUrl(url)} alt={title || 'media'} className="w-full h-full object-cover" />
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/admin/media/MediaModalLayout.jsx
+++ b/src/components/admin/media/MediaModalLayout.jsx
@@ -1,0 +1,18 @@
+export default function MediaModalLayout({ open, title, onClose, children, footer }) {
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50" onClick={onClose}>
+      <div
+        className="bg-white rounded-lg shadow-xl w-full max-w-3xl mx-4 flex flex-col max-h-[80vh] overflow-hidden"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="p-4 border-b flex items-center justify-between flex-shrink-0">
+          <h3 className="text-lg font-semibold">{title}</h3>
+        </div>
+        <div className="p-4 flex-1 overflow-y-auto">{children}</div>
+        {footer && <div className="p-3 border-t flex justify-end flex-shrink-0">{footer}</div>}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/media/MediaTabs.jsx
+++ b/src/components/admin/media/MediaTabs.jsx
@@ -1,0 +1,18 @@
+export default function MediaTabs({ tabs, activeTab, onTabChange }) {
+  return (
+    <div className="flex items-center gap-2">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          className={`px-3 py-1.5 text-sm rounded border ${
+            activeTab === tab.id ? 'bg-gray-900 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'
+          }`}
+          onClick={() => onTabChange(tab.id)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/components/admin/media/ReferencePicker.jsx
+++ b/src/components/admin/media/ReferencePicker.jsx
@@ -1,0 +1,71 @@
+import { Button } from '../../ui/button'
+
+export default function ReferencePicker({
+  open,
+  loading,
+  items,
+  selected,
+  onToggle,
+  onClear,
+  onApply,
+  onClose,
+}) {
+  if (!open) return null
+
+  const footer = (
+    <div className="mt-3 flex items-center justify-between text-sm">
+      <div className="text-gray-600">{selected.size}/3 selected</div>
+      <div className="flex gap-2">
+        <Button type="button" variant="outline" onClick={onClear}>
+          Clear
+        </Button>
+        <Button type="button" onClick={onApply} disabled={selected.size === 0}>
+          Use selected
+        </Button>
+      </div>
+    </div>
+  )
+
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50" onClick={onClose}>
+      <div
+        className="bg-white rounded-lg shadow-xl w-full max-w-3xl mx-4 p-4"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h4 className="text-base font-semibold">Select reference images</h4>
+          <button className="text-sm underline" onClick={onClose}>
+            Close
+          </button>
+        </div>
+        {loading ? (
+          <p className="text-sm text-gray-500">Loading…</p>
+        ) : (
+          <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 max-h-80 overflow-auto">
+            {items.map((url, index) => {
+              const isSelected = selected.has(url)
+              return (
+                <button
+                  key={index}
+                  type="button"
+                  className={`relative aspect-square rounded border overflow-hidden ${
+                    isSelected ? 'ring-2 ring-purple-500' : 'hover:ring-2 hover:ring-purple-300'
+                  }`}
+                  onClick={() => onToggle(url)}
+                >
+                  <img src={url} alt="library" className="w-full h-full object-cover" />
+                  {isSelected && (
+                    <span className="absolute top-1 left-1 bg-purple-600 text-white text-[10px] px-1 rounded">
+                      Selected
+                    </span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        )}
+        {footer}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/media/ReferenceSlots.jsx
+++ b/src/components/admin/media/ReferenceSlots.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react'
+
+function SlotPreview({ file, onClear }) {
+  const [src, setSrc] = useState('')
+
+  useEffect(() => {
+    const url = URL.createObjectURL(file)
+    setSrc(url)
+    return () => URL.revokeObjectURL(url)
+  }, [file])
+
+  return (
+    <div className="relative w-full h-full">
+      <img src={src} alt="preview" className="absolute inset-0 w-full h-full object-cover" />
+      <button
+        type="button"
+        onClick={(event) => {
+          event.preventDefault()
+          onClear?.()
+        }}
+        className="absolute top-1 right-1 bg-white/80 hover:bg-white text-gray-700 rounded px-2 py-0.5 text-xs border"
+      >
+        Clear
+      </button>
+    </div>
+  )
+}
+
+export default function ReferenceSlots({ files, onChange, slots = 4 }) {
+  return (
+    <div className="grid grid-cols-4 gap-2">
+      {Array.from({ length: slots }).map((_, index) => {
+        const file = files[index] || null
+        const hasFile = !!file
+        return (
+          <label
+            key={index}
+            className="aspect-square border rounded-md flex items-center justify-center cursor-pointer bg-gray-50 hover:bg-gray-100 overflow-hidden"
+          >
+            <input
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(event) => {
+                const nextFile = event.target.files && event.target.files[0] ? event.target.files[0] : null
+                onChange(index, nextFile)
+              }}
+            />
+            {hasFile ? (
+              <SlotPreview file={file} onClear={() => onChange(index, null)} />
+            ) : (
+              <div className="flex flex-col items-center text-gray-500 text-sm">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M12 5v14" />
+                  <path d="M5 12h14" />
+                </svg>
+                <span className="mt-1">Add</span>
+              </div>
+            )}
+          </label>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/admin/media/__tests__/MediaGrid.test.jsx
+++ b/src/components/admin/media/__tests__/MediaGrid.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import MediaGrid from '../MediaGrid'
+
+describe('MediaGrid', () => {
+  it('renders an empty message when no items are provided', () => {
+    render(
+      <MediaGrid items={[]} onSelect={vi.fn()} emptyMessage="Nothing to see" />
+    )
+
+    expect(screen.getByText('Nothing to see')).toBeInTheDocument()
+  })
+
+  it('invokes onSelect when an item is clicked', async () => {
+    const user = userEvent.setup()
+    const handleSelect = vi.fn()
+    render(
+      <MediaGrid
+        items={[{ id: '1', url: 'https://example.com/image.png' }]}
+        onSelect={handleSelect}
+        emptyMessage=""
+      />
+    )
+
+    await user.click(screen.getByRole('button'))
+    expect(handleSelect).toHaveBeenCalledWith('https://example.com/image.png')
+  })
+})

--- a/src/components/admin/media/__tests__/MediaModalLayout.test.jsx
+++ b/src/components/admin/media/__tests__/MediaModalLayout.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import MediaModalLayout from '../MediaModalLayout'
+
+describe('MediaModalLayout', () => {
+  it('does not render when closed', () => {
+    const { container } = render(
+      <MediaModalLayout open={false} title="Test" onClose={() => {}}>
+        <p>Content</p>
+      </MediaModalLayout>
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders content when open', () => {
+    render(
+      <MediaModalLayout open title="Title" onClose={() => {}} footer={<div>Footer</div>}>
+        <p>Body</p>
+      </MediaModalLayout>
+    )
+
+    expect(screen.getByText('Body')).toBeInTheDocument()
+    expect(screen.getByText('Footer')).toBeInTheDocument()
+  })
+})

--- a/src/components/admin/media/__tests__/MediaTabs.test.jsx
+++ b/src/components/admin/media/__tests__/MediaTabs.test.jsx
@@ -1,0 +1,24 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import MediaTabs from '../MediaTabs'
+
+describe('MediaTabs', () => {
+  it('calls onTabChange when a tab is clicked', async () => {
+    const user = userEvent.setup()
+    const handleChange = vi.fn()
+    render(
+      <MediaTabs
+        tabs={[
+          { id: 'one', label: 'One' },
+          { id: 'two', label: 'Two' },
+        ]}
+        activeTab="one"
+        onTabChange={handleChange}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Two' }))
+    expect(handleChange).toHaveBeenCalledWith('two')
+  })
+})

--- a/src/components/admin/media/__tests__/ReferenceSlots.test.jsx
+++ b/src/components/admin/media/__tests__/ReferenceSlots.test.jsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import ReferenceSlots from '../ReferenceSlots'
+
+let originalCreateObjectURL
+let originalRevokeObjectURL
+
+describe('ReferenceSlots', () => {
+  beforeAll(() => {
+    originalCreateObjectURL = global.URL.createObjectURL
+    originalRevokeObjectURL = global.URL.revokeObjectURL
+    global.URL.createObjectURL = vi.fn(() => 'blob://preview')
+    global.URL.revokeObjectURL = vi.fn()
+  })
+
+  afterAll(() => {
+    global.URL.createObjectURL = originalCreateObjectURL
+    global.URL.revokeObjectURL = originalRevokeObjectURL
+  })
+
+  it('notifies when files are selected and cleared', async () => {
+    const user = userEvent.setup()
+    const handleChange = vi.fn()
+    const file = new File(['hello'], 'hello.png', { type: 'image/png' })
+
+    const { container, rerender } = render(<ReferenceSlots files={[]} onChange={handleChange} />)
+
+    const input = container.querySelector('input[type="file"]')
+    fireEvent.change(input, { target: { files: [file] } })
+    expect(handleChange).toHaveBeenCalledWith(0, file)
+
+    rerender(<ReferenceSlots files={[file]} onChange={handleChange} />)
+    await user.click(screen.getByRole('button', { name: /clear/i }))
+    expect(handleChange).toHaveBeenCalledWith(0, null)
+  })
+})

--- a/src/components/admin/media/__tests__/useDriveStatus.test.js
+++ b/src/components/admin/media/__tests__/useDriveStatus.test.js
@@ -1,0 +1,56 @@
+import { renderHook, act } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useDriveStatus } from '../useDriveStatus'
+
+vi.mock('../../../lib/auth', () => ({
+  adminApiRequest: vi.fn(),
+}))
+
+const { adminApiRequest } = await import('../../../lib/auth')
+
+describe('useDriveStatus', () => {
+  afterEach(() => {
+    adminApiRequest.mockReset()
+  })
+
+  it('checks drive status and updates state', async () => {
+    adminApiRequest.mockResolvedValueOnce({
+      json: vi.fn().mockResolvedValue({ connected: true }),
+    })
+
+    const { result } = renderHook(() => useDriveStatus())
+
+    await act(async () => {
+      await result.current.checkDriveStatus()
+    })
+
+    expect(result.current.driveConnected).toBe(true)
+    expect(result.current.error).toBe('')
+  })
+
+  it('handles disconnect failures', async () => {
+    adminApiRequest.mockResolvedValueOnce({ ok: false, json: vi.fn() })
+
+    const { result } = renderHook(() => useDriveStatus())
+
+    await act(async () => {
+      const success = await result.current.disconnectDrive()
+      expect(success).toBe(false)
+    })
+
+    expect(result.current.error).toContain('Failed to disconnect')
+  })
+
+  it('disconnects successfully when API returns ok', async () => {
+    adminApiRequest.mockResolvedValueOnce({ ok: true, json: vi.fn() })
+
+    const { result } = renderHook(() => useDriveStatus())
+
+    await act(async () => {
+      const success = await result.current.disconnectDrive()
+      expect(success).toBe(true)
+    })
+
+    expect(result.current.driveConnected).toBe(false)
+  })
+})

--- a/src/components/admin/media/mediaUtils.js
+++ b/src/components/admin/media/mediaUtils.js
@@ -1,0 +1,34 @@
+export function fileToDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
+}
+
+export function parseDataUrl(dataUrl) {
+  const match = String(dataUrl).match(/^data:([^;]+);base64,(.*)$/)
+  if (!match) return { mimeType: 'application/octet-stream', base64: '' }
+  return { mimeType: match[1], base64: match[2] }
+}
+
+export function buildDataUrl({ mimeType, base64 }) {
+  if (!mimeType || !base64) return ''
+  return `data:${mimeType};base64,${base64}`
+}
+
+export function blobToBase64(blob) {
+  return new Promise((resolve) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const match = String(reader.result).match(/^data:([^;]+);base64,(.*)$/)
+      if (match) {
+        resolve({ mimeType: match[1], base64: match[2] })
+      } else {
+        resolve({ mimeType: blob.type || 'image/png', base64: '' })
+      }
+    }
+    reader.readAsDataURL(blob)
+  })
+}

--- a/src/components/admin/media/useDriveStatus.js
+++ b/src/components/admin/media/useDriveStatus.js
@@ -1,0 +1,34 @@
+import { useCallback, useState } from 'react'
+import { adminApiRequest } from '../../../lib/auth'
+
+export function useDriveStatus() {
+  const [driveConnected, setDriveConnected] = useState(false)
+  const [error, setError] = useState('')
+
+  const checkDriveStatus = useCallback(async () => {
+    try {
+      const res = await adminApiRequest('/api/admin/drive/status', { method: 'GET' })
+      const data = await res.json()
+      setDriveConnected(!!data.connected)
+      setError('')
+    } catch (_) {
+      setDriveConnected(false)
+      setError('')
+    }
+  }, [])
+
+  const disconnectDrive = useCallback(async () => {
+    try {
+      const res = await adminApiRequest('/api/admin/drive/disconnect', { method: 'POST' })
+      if (!res.ok) throw new Error('Failed to disconnect')
+      setDriveConnected(false)
+      setError('')
+      return true
+    } catch (err) {
+      setError(err.message || 'Failed to disconnect Google Drive')
+      return false
+    }
+  }, [])
+
+  return { driveConnected, checkDriveStatus, disconnectDrive, error, setError }
+}

--- a/src/components/admin/product-form/ProductImageFields.jsx
+++ b/src/components/admin/product-form/ProductImageFields.jsx
@@ -1,0 +1,39 @@
+import { Button } from '../../ui/button'
+import ImageUrlField from '../ImageUrlField'
+
+export default function ProductImageFields({
+  images,
+  onImageChange,
+  onAddImage,
+  onRemoveImage,
+  onPreviewImage,
+  notice,
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <label className="block text-sm font-medium">Product Images</label>
+        <Button type="button" variant="outline" size="sm" onClick={onAddImage}>
+          Add Image
+        </Button>
+      </div>
+      <div className="space-y-2">
+        {images.map((image, index) => (
+          <ImageUrlField
+            key={index}
+            value={image}
+            onChange={(value) => onImageChange(index, value)}
+            placeholder={`Image URL ${index + 1}`}
+            onPreview={onPreviewImage}
+            onRemove={images.length > 1 ? () => onRemoveImage(index) : undefined}
+            hideInput
+          />
+        ))}
+      </div>
+      {notice && <p className="text-xs text-purple-700 mt-2">{notice}</p>}
+      <p className="text-sm text-gray-500 mt-1">
+        Add multiple images for your product. The first image will be the primary image.
+      </p>
+    </div>
+  )
+}

--- a/src/components/admin/product-form/VariantGroup.jsx
+++ b/src/components/admin/product-form/VariantGroup.jsx
@@ -1,0 +1,126 @@
+import { Fragment } from 'react'
+import { Button } from '../../ui/button'
+import { Input } from '../../ui/input'
+import { Switch } from '../../ui/switch'
+import ImageUrlField from '../ImageUrlField'
+
+export default function VariantGroup({
+  id,
+  enabled,
+  onToggle,
+  title,
+  description,
+  styleLabel,
+  styleValue,
+  onStyleChange,
+  stylePlaceholder,
+  variants,
+  onAddVariant,
+  onVariantChange,
+  onVariantRemove,
+  emptyMessage,
+  priceLabel,
+  namePlaceholder,
+  onPreviewImage,
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <Switch id={id} checked={enabled} onCheckedChange={onToggle} />
+        <label htmlFor={id} className="text-sm text-gray-700 select-none">
+          {description}
+        </label>
+      </div>
+      {enabled && (
+        <Fragment>
+          <h3 className="text-lg font-medium text-gray-900">{title}</h3>
+          <div>
+            <label className="block text-sm font-medium mb-2">{styleLabel}</label>
+            <Input
+              value={styleValue}
+              onChange={(event) => onStyleChange(event.target.value)}
+              placeholder={stylePlaceholder}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <label className="block text-sm font-medium">Variant Picker</label>
+            <Button type="button" variant="outline" size="sm" onClick={onAddVariant}>
+              Add Variant
+            </Button>
+          </div>
+          <div className="grid grid-cols-12 gap-2 text-xs text-gray-600 px-1">
+            <div className="col-span-3">Variant name</div>
+            <div className="col-span-4">Selector image</div>
+            <div className="col-span-4">Display image</div>
+          </div>
+          {variants.length === 0 ? (
+            <p className="text-sm text-gray-500">{emptyMessage}</p>
+          ) : (
+            <div className="space-y-2">
+              {variants.map((variant, index) => (
+                <div key={variant.id || index} className="grid grid-cols-12 gap-2 items-center">
+                  <div className="col-span-3">
+                    <Input
+                      value={variant.name}
+                      onChange={(event) => onVariantChange(index, 'name', event.target.value)}
+                      placeholder={namePlaceholder}
+                    />
+                  </div>
+                  <div className="col-span-4">
+                    <ImageUrlField
+                      value={variant.selectorImageUrl || ''}
+                      onChange={(value) => onVariantChange(index, 'selectorImageUrl', value)}
+                      placeholder="Selector image URL"
+                      onPreview={onPreviewImage}
+                      hideInput
+                    />
+                  </div>
+                  <div className="col-span-4">
+                    <ImageUrlField
+                      value={variant.displayImageUrl || ''}
+                      onChange={(value) => onVariantChange(index, 'displayImageUrl', value)}
+                      placeholder="Display image URL"
+                      onPreview={onPreviewImage}
+                      hideInput
+                    />
+                  </div>
+                  <div className="col-span-12 grid grid-cols-12 gap-2 items-center">
+                    <label className="col-span-3 flex items-center gap-2 text-sm text-gray-700">
+                      <Switch
+                        checked={!!variant.hasCustomPrice}
+                        onCheckedChange={(value) => onVariantChange(index, 'hasCustomPrice', value)}
+                      />
+                      {priceLabel}
+                    </label>
+                    <div className="col-span-3">
+                      <Input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        disabled={!variant.hasCustomPrice}
+                        value={variant.price ?? ''}
+                        onChange={(event) => onVariantChange(index, 'price', event.target.value)}
+                        placeholder="Variant price"
+                      />
+                    </div>
+                  </div>
+                  <div className="col-span-1 text-right">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="px-3"
+                      onClick={() => onVariantRemove(index)}
+                    >
+                      ×
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </Fragment>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/product-form/__tests__/VariantGroup.test.jsx
+++ b/src/components/admin/product-form/__tests__/VariantGroup.test.jsx
@@ -1,0 +1,64 @@
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import VariantGroup from '../VariantGroup'
+
+function createProps(overrides = {}) {
+  return {
+    id: 'group-1',
+    enabled: true,
+    onToggle: vi.fn(),
+    title: 'Variants',
+    description: 'Enable variants',
+    styleLabel: 'Style',
+    styleValue: 'Color',
+    onStyleChange: vi.fn(),
+    stylePlaceholder: 'Color',
+    variants: [
+      {
+        id: 'v1',
+        name: 'Green',
+        selectorImageUrl: '',
+        displayImageUrl: '',
+        hasCustomPrice: false,
+        price: '',
+      },
+    ],
+    onAddVariant: vi.fn(),
+    onVariantChange: vi.fn(),
+    onVariantRemove: vi.fn(),
+    emptyMessage: 'No variants',
+    priceLabel: 'Custom price',
+    namePlaceholder: 'Variant name',
+    onPreviewImage: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('VariantGroup', () => {
+  it('calls callbacks for toggle, add, change, and remove actions', async () => {
+    const user = userEvent.setup()
+    const props = createProps()
+    render(<VariantGroup {...props} />)
+
+    await user.click(screen.getByRole('switch', { name: /enable variants/i }))
+    expect(props.onToggle).toHaveBeenCalledWith(false)
+
+    await user.click(screen.getByRole('button', { name: /add variant/i }))
+    expect(props.onAddVariant).toHaveBeenCalled()
+
+    const nameInput = screen.getAllByPlaceholderText(/Variant name/i)[0]
+    await user.type(nameInput, ' updated')
+    expect(props.onVariantChange).toHaveBeenCalledWith(0, 'name', 'Green updated')
+
+    await user.click(screen.getByRole('button', { name: '×' }))
+    expect(props.onVariantRemove).toHaveBeenCalledWith(0)
+  })
+
+  it('renders empty message when variants list is empty', () => {
+    const props = createProps({ variants: [], emptyMessage: 'Nothing here' })
+    render(<VariantGroup {...props} />)
+
+    expect(screen.getByText('Nothing here')).toBeInTheDocument()
+  })
+})

--- a/src/components/admin/product-form/__tests__/useDriveImageNormalizer.test.js
+++ b/src/components/admin/product-form/__tests__/useDriveImageNormalizer.test.js
@@ -1,0 +1,27 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useDriveImageNormalizer } from '../useDriveImageNormalizer'
+
+describe('useDriveImageNormalizer', () => {
+  it('normalizes Google Drive links and exposes a temporary notice', () => {
+    vi.useFakeTimers()
+
+    const { result } = renderHook(() => useDriveImageNormalizer({ noticeDuration: 100 }))
+
+    let normalized
+    act(() => {
+      normalized = result.current.normalize('https://drive.google.com/file/d/abc123/view?usp=sharing')
+    })
+
+    expect(normalized).toBe('https://drive.usercontent.google.com/download?id=abc123&export=view')
+    expect(result.current.notice).toContain('Google Drive link detected')
+
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    expect(result.current.notice).toBe('')
+
+    vi.useRealTimers()
+  })
+})

--- a/src/components/admin/product-form/useDriveImageNormalizer.js
+++ b/src/components/admin/product-form/useDriveImageNormalizer.js
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const DRIVE_NOTICE = 'Google Drive link detected — converted for reliable preview and delivery.'
+
+export function useDriveImageNormalizer({ noticeDuration = 3000 } = {}) {
+  const [notice, setNotice] = useState('')
+  const timerRef = useRef(null)
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [])
+
+  const normalize = useCallback((input) => {
+    const value = (input || '').trim()
+    if (!value) return input
+
+    const isDriveLink = value.includes('drive.google.com') || value.includes('drive.usercontent.google.com')
+    if (!isDriveLink) return input
+
+    const fileMatch = value.match(/\/file\/d\/([a-zA-Z0-9_-]+)/)
+    const idMatch = value.match(/[?&#]id=([a-zA-Z0-9_-]+)/)
+    const id = (fileMatch && fileMatch[1]) || (idMatch && idMatch[1]) || null
+    const normalized = id
+      ? `https://drive.usercontent.google.com/download?id=${id}&export=view`
+      : value
+
+    if (normalized !== value) {
+      setNotice(DRIVE_NOTICE)
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => setNotice(''), noticeDuration)
+    }
+
+    return normalized
+  }, [noticeDuration])
+
+  const clearNotice = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    setNotice('')
+  }, [])
+
+  return { normalize, notice, clearNotice }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,4 +8,9 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.js',
+  },
 })

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'


### PR DESCRIPTION
## Summary
- break the product form into reusable subcomponents and a drive URL normalizer hook
- refactor the admin media modals to share common layout, tabs, and drive status utilities
- add vitest configuration with focused component and hook tests for the new building blocks

## Testing
- `npm test` *(fails: vitest not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e44d4c1d488329b470db559276e946