### PR TITLE
Add Puck storefront page editor

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -14,6 +14,7 @@ These endpoints are publicly accessible and require no authentication.
 | `/api/collections/:id` | `GET` | Get single collection | None |
 | `/api/collections/:id/products` | `GET` | Get products in collection | None |
 | `/api/store-settings` | `GET` | Get store configuration | None |
+| `/api/storefront/pages/:slug` | `GET` | Get Puck page-builder content for `home` or `about` | None |
 
 ## Checkout Endpoints
 
@@ -35,6 +36,7 @@ These endpoints require admin authentication via the `X-Admin-Token` header.
 | `/api/admin/products` | `POST` | Create product | Admin Token |
 | `/api/admin/products/:id` | `PUT, DELETE` | Update/delete product | Admin Token |
 | `/api/admin/store-settings` | `PUT` | Update store settings | Admin Token |
+| `/api/admin/storefront/pages/:slug` | `GET, PUT` | Load or publish Puck page-builder content for `home` or `about` | Admin Token |
 | `/api/analytics` | `GET` | Revenue and order analytics | Admin Token |
 | `/api/admin/ai/generate-image` | `POST` | Generate image via Gemini | Admin Token |
 | `/api/admin/drive/status` | `GET` | Google Drive connection status | Admin Token |

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -16,6 +16,7 @@ React 19 + Vite + Tailwind CSS 4 + ShadCN-style components under `src/components
 src/pages/storefront/   # Public shop pages
 src/pages/admin/        # Admin shell (AdminDashboard, AdminLayout) + feature pages
 src/components/storefront/
+src/components/storefront/page-builder/  # Puck config + render-only storefront blocks
 src/components/admin/store-settings/  # Shared store settings / theme form helpers
 src/components/admin/
 src/components/ui/      # Shared primitives (button, card, input, …)
@@ -29,6 +30,7 @@ src/api/                # Fetch wrappers for public/admin APIs
 - **Images:** Use `normalizeImageUrl` from `src/lib/utils.js` for consistent CDN/proxy URLs.
 - **Admin auth:** `adminApiRequest` attaches `X-Admin-Token` from session storage.
 - **Cart:** `CartContext` persists to `localStorage`.
+- **Page builder:** Home/About content is stored as Puck JSON from `/api/storefront/pages/:slug`; `Navbar`, `Footer`, product pages, collection pages, cart, and checkout remain outside Puck.
 
 ## Routing
 

--- a/docs/generated/kv-data-model.md
+++ b/docs/generated/kv-data-model.md
@@ -18,6 +18,7 @@
 | `collection:{id}` | Collection document |
 | `collection:products:{collectionId}` | JSON array of product IDs in collection |
 | `media:{id}` | Media metadata record |
+| `storefront:page:{slug}` | Puck page-builder document for `home` or `about` |
 
 ## Product shape (typical)
 
@@ -57,6 +58,30 @@
   "driveFileId": "string",
   "createdAt": 0,
   "updatedAt": 0
+}
+```
+
+## Storefront page shape
+
+```json
+{
+  "slug": "home",
+  "version": 1,
+  "updatedAt": "2026-05-28T00:00:00.000Z",
+  "data": {
+    "content": [
+      {
+        "type": "HeroSection",
+        "props": {
+          "id": "home-hero",
+          "title": "Welcome to OpenShop"
+        }
+      }
+    ],
+    "root": {
+      "props": {}
+    }
+  }
 }
 ```
 

--- a/docs/product-specs/core-ecommerce.md
+++ b/docs/product-specs/core-ecommerce.md
@@ -16,6 +16,7 @@ Storefront browse, cart, Stripe checkout, and admin CRUD for products and collec
 - Login at `/admin` with password → token.
 - CRUD products (images, variants, archive) and collections (hero image).
 - Store settings: branding, theme-related fields.
+- Website editor: Home and About page content use Puck JSON stored in KV; products, collections, cart, checkout, navigation, and footer remain code-owned storefront behavior.
 - Analytics: revenue/orders from Stripe (admin-only).
 
 ## Out of scope

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@hono/node-server": "^1.19.1",
+        "@puckeditor/core": "^0.21.2",
         "@stripe/stripe-js": "^7.9.0",
         "@tailwindcss/vite": "^4.1.13",
         "class-variance-authority": "^0.7.1",
@@ -439,6 +440,87 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dnd-kit/abstract": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/abstract/-/abstract-0.1.21.tgz",
+      "integrity": "sha512-6sJut6/D21xPIK8EFMu+JJeF+fBCOmQKN1BRpeUYFi5m9P1CJpTYbBwfI107h7PHObI6a5bsckiKkRpF2orHpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/geometry": "^0.1.21",
+        "@dnd-kit/state": "^0.1.21",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/collision": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/collision/-/collision-0.1.21.tgz",
+      "integrity": "sha512-9AJ4NbuwGDexxMCZXZyKdNQhbAe93p6C6IezQaDaWmdCqZHMHmC3+ul7pGefBQfOooSarGwIf8Bn182o9SMa1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.1.21",
+        "@dnd-kit/geometry": "^0.1.21",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/dom": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/dom/-/dom-0.1.21.tgz",
+      "integrity": "sha512-6UDc1y2Y3oLQKArGlgCrZxz5pdEjRSiQujXOn5JdbuWvKqTdUR5RTYDeicr+y2sVm3liXjTqs3WlUoV+eqhqUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.1.21",
+        "@dnd-kit/collision": "^0.1.21",
+        "@dnd-kit/geometry": "^0.1.21",
+        "@dnd-kit/state": "^0.1.21",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/geometry": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/geometry/-/geometry-0.1.21.tgz",
+      "integrity": "sha512-Tir97wNJbopN2HgkD7AjAcoB3vvrVuUHvwdPALmNDUH0fWR637c4MKQ66YjjZAbUEAR8KL6mlDiHH4MzTLd7CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/state": "^0.1.21",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/helpers": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/helpers/-/helpers-0.1.18.tgz",
+      "integrity": "sha512-k4hVXIb8ysPt+J0KOxbBTc6rG0JSlsrNevI/fCHLbyXvEyj1imxl7yOaAQX13cAZnte88db6JvbgsSWlVjtxbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.1.18",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/react": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/react/-/react-0.1.18.tgz",
+      "integrity": "sha512-OCeCO9WbKnN4rVlEOEe9QWxSIFzP0m/fBFmVYfu2pDSb4pemRkfrvCsI/FH3jonuESYS8qYnN9vc8Vp3EiCWCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.1.18",
+        "@dnd-kit/dom": "^0.1.18",
+        "@dnd-kit/state": "^0.1.18",
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/state": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/state/-/state-0.1.21.tgz",
+      "integrity": "sha512-pdhntEPvn/QttcF295bOJpWiLsRqA/Iczh1ODOJUxGiR+E4GkYVz9VapNNm9gDq6ST0tr/e1Q2xBztUHlJqQgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.10.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1035,6 +1117,44 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.1.tgz",
@@ -1565,6 +1685,503 @@
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.2.tgz",
       "integrity": "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.2.tgz",
+      "integrity": "sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@puckeditor/core": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@puckeditor/core/-/core-0.21.2.tgz",
+      "integrity": "sha512-XFkIb2Q5f74bG6FmNlupOfythTszythVSOm2ByeUwez5ePpWSUl94zy8GGxAbDLLqja4Pkx9TnLuuwZx2225aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/helpers": "0.1.18",
+        "@dnd-kit/react": "0.1.18",
+        "@radix-ui/react-popover": "^1.1.15",
+        "@tanstack/react-virtual": "^3.13.9",
+        "@tiptap/core": "^3.11.1",
+        "@tiptap/extension-blockquote": "^3.11.1",
+        "@tiptap/extension-bold": "^3.11.1",
+        "@tiptap/extension-code": "^3.11.1",
+        "@tiptap/extension-code-block": "^3.11.1",
+        "@tiptap/extension-document": "^3.11.1",
+        "@tiptap/extension-hard-break": "^3.11.1",
+        "@tiptap/extension-heading": "^3.11.1",
+        "@tiptap/extension-horizontal-rule": "^3.11.1",
+        "@tiptap/extension-italic": "^3.11.1",
+        "@tiptap/extension-link": "^3.11.1",
+        "@tiptap/extension-list": "^3.11.1",
+        "@tiptap/extension-paragraph": "^3.11.1",
+        "@tiptap/extension-strike": "^3.11.1",
+        "@tiptap/extension-text": "^3.11.1",
+        "@tiptap/extension-text-align": "^3.11.1",
+        "@tiptap/extension-underline": "^3.11.1",
+        "@tiptap/html": "^3.11.1",
+        "@tiptap/pm": "^3.11.1",
+        "@tiptap/react": "^3.11.1",
+        "deep-diff": "^1.0.2",
+        "fast-equals": "5.2.2",
+        "flat": "^5.0.2",
+        "happy-dom": "^20.0.10",
+        "object-hash": "^3.0.0",
+        "react-hotkeys-hook": "^4.6.1",
+        "use-debounce": "^9.0.4",
+        "uuid": "^9.0.1",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@puckeditor/core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
@@ -2135,6 +2752,370 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.26",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.26.tgz",
+      "integrity": "sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.16.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.16.0.tgz",
+      "integrity": "sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tiptap/core": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.6.tgz",
+      "integrity": "sha512-MRB3pHz4Oxqmcawh0cQ5iOGdY5xtNYp/1CoK7hdTLzw5K0C6/gTC2VvanB1R4INaB6EpBkxG/GiWkVirDRnuXw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.23.6.tgz",
+      "integrity": "sha512-2RmnqNqTltZ2k1F7IfjoDNs935Uq4rRDR7d98mqkg3OlDktcQIyBpv0t9dTay6H5bkQeZUuS8ogK2S1E8Edjug==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.23.6.tgz",
+      "integrity": "sha512-1LMhjnytdbbhWHSoOwnLxZAOQZWPkKyXVCNmaIk0Mhi4tLPUXptG4qKS5sVYTCveE5H6IBPFrbgBFi5dMI6krA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.23.6.tgz",
+      "integrity": "sha512-Mwkyp9LkDHFbqmWRIkp63FinRxFu3ajC4qSb9t4mnHsb4kAdbNLLsGtbFg+le0SWk4CxGwAOwM7SzeJ+6UGqCA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.23.6.tgz",
+      "integrity": "sha512-KG8KXFYyLrtYvT7AZ1WGV61ofx8pDe5g9pH658MERxqQGii+Pyfc6xkz04l7XeBts/7+571UQp/0O7i/z560TA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.23.6.tgz",
+      "integrity": "sha512-4kccgcn5yHThxrzsIhJny3EwfEZYIk+BjUCL4uIuzOyWvExtGhZ6JMHVCZeMhI8D1/bX1LNkkAKN5DXPzH4lXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.23.6.tgz",
+      "integrity": "sha512-XDAIgG9KcKumFM9KJWUEUhXPbFIhhl47bfy5GknareWTRKke85rcoj/oxKKO9ihLZr8JfpbXjqnS4SCm5yhYPw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.23.6.tgz",
+      "integrity": "sha512-2kjuDcEq69lEcECl75xqY5MyzUSh2zcC5aLrpwP1WwhJz5bxsIFHiaps5AP6h9R4A+ZBj5b2haay2Y1wDUU3VA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.23.6.tgz",
+      "integrity": "sha512-KeUm+tkUfIVSX9QM9XOIhaay0Fn36sLKUo5NVYjN3uJaxFvaZXZmTlxdO85OTdgF2P5sqh9LomrIgliaFRGk4w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.23.6.tgz",
+      "integrity": "sha512-A/0jPhxnUh9THSZymlu0OGPZe1wdFdwHAXnRCmqvYUCwJjrG7LCC/ahzmcj1tcNzI9hgHyuYPSfev8RXYrNu/w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.23.6.tgz",
+      "integrity": "sha512-hEUlz4H+I64r+TH6LCuNCRgO7JTHncXGmx9+WbU69EOfY8O0ZurcgeJc8HeiAKL+r9YuC1e5YHfFxgCaaC0jlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.23.6.tgz",
+      "integrity": "sha512-wol5KdwCPAvpiYhH9PLlvO8ZnJHwZtIboVevrfOGgBcKlXRA3dedR4OAMXHnUtkkzu9KtliLg1+TYzEx4JZG9Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.23.6.tgz",
+      "integrity": "sha512-KNZz7z7P2/qbQsx5bPAbSPjrKDg1VHsedGlLHJCr8U2VRD5VgmDLkMpkouP1CsDg15qgyUKv/nDib5KgPpLNWA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.23.6.tgz",
+      "integrity": "sha512-z6vj9+Qht2sjdQkyyHcUpsC/yCIZqTrQiyHDhs/HGKrfvoANyAZGpqdNeKf1wSyjIso+27tQuIH5NDfk8ygyNw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.23.6.tgz",
+      "integrity": "sha512-+7m58LUSncodjrIyXks4RZ3tLNYrvgT77wRR4l3HnM5OABY3GDsDTqi7c1t1yI29NVOSk/DUacqy6UwYAj1DGg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.23.6.tgz",
+      "integrity": "sha512-oF7FEZ37f15aCe5kPgzGDYf/m+hr7VdQ/Ko/Hds/UM9pX7AG1fdtmRrl6wqkRqDM/incZaC/AQR2/Dpo2VCNGQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.23.6.tgz",
+      "integrity": "sha512-ipoC2TkIAIOTiF5ByiGgvQB1DqDyfP90wrUB3mohBcgvp7lQnwHszCDGv8dNnmcUek8uXV/uoLu2VXeVQlxjPA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-text-align": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.23.6.tgz",
+      "integrity": "sha512-pE+gDmvnrSMWHADDnDSzaO7YUi9kOywQkyrqZ9bEPLddZred7ICoJ4NtD2DqLjDSur+HijaJuByResWb78c6FA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.23.6.tgz",
+      "integrity": "sha512-P55wGIZGYTVH92Fq0cgI4/O9AhLCaJC3hhxg15RSERP5/YegM9eJHDK/GQ1EE/DvYA+xpYGOV6agKwAUqfA/Iw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/html": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/html/-/html-3.23.6.tgz",
+      "integrity": "sha512-cfQ8ijvkhkbt02x0tjtcahubWCqxkO7IJow0j2MgS6FHdXKv2QUrIvcpAqIqdv0lA4ozWmdmUpLFv+lA95kcPg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6",
+        "happy-dom": "^20.8.9"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.6.tgz",
+      "integrity": "sha512-in5CaMaWlJcH2A1q6GJKFtrodE8WLS3M9tIi/f89jPmIVHJShpodC0KZDNyJkrVBQomYk0DEh86Utm6ASXzQww==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.23.6.tgz",
+      "integrity": "sha512-Tw9KZkYqFMk3vaJAEQKqEYIO/iq3cSJe7OUEGBul4k4GaMQeLItLf5EYhUd0GIPXci1WVVPNntKJsHfX25M37w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.23.6",
+        "@tiptap/extension-floating-menu": "^3.23.6"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/react/node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2241,11 +3222,19 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
-      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2254,7 +3243,6 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-      "dev": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2263,6 +3251,21 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.0.2",
@@ -2451,6 +3454,18 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2733,8 +3748,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -2868,6 +3882,13 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
+    "node_modules/deep-diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2899,6 +3920,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2928,6 +3955,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-stack-parser-es": {
@@ -3264,6 +4303,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3318,6 +4366,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -3392,6 +4449,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -3450,6 +4516,44 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3892,6 +4996,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4086,6 +5196,15 @@
       "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==",
       "dev": true
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -4120,6 +5239,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -4257,6 +5382,135 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
+      "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4299,6 +5553,16 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-hotkeys-hook": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.6.2.tgz",
+      "integrity": "sha512-FmP+ZriY3EG59Ug/lxNfrObCnW9xQShgk7Nb83+CkpfkcCpfS95ydv+E9JuXA5cp8KtskU7LGlIARpkc92X22Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
@@ -4336,6 +5600,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
@@ -4370,6 +5681,28 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/recharts": {
@@ -4463,6 +5796,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.50.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -4836,8 +6175,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4867,6 +6205,12 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.21",
@@ -4919,6 +6263,61 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.4.tgz",
+      "integrity": "sha512-6X8H/mikbrt0XE8e+JXRtZ8yYVvKkdYRfmIhWZYsP8rcNs9hk3APV8Ua2mFkKRLcJKVdnX2/Vwrmg2GWKUQEaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {
@@ -6586,6 +7985,21 @@
         }
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7222,6 +8636,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.1",
+    "@puckeditor/core": "^0.21.2",
     "@stripe/stripe-js": "^7.9.0",
     "@tailwindcss/vite": "^4.1.13",
     "class-variance-authority": "^0.7.1",

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -68,6 +68,10 @@ export const adminAPI = {
       update: (data) => apiClient.put(API_ENDPOINTS.admin.settings.theme.update, data),
       reset: () => apiClient.delete(API_ENDPOINTS.admin.settings.theme.reset)
     },
+    pages: {
+      get: (slug) => apiClient.get(API_ENDPOINTS.admin.settings.pages.get(slug)),
+      update: (slug, data) => apiClient.put(API_ENDPOINTS.admin.settings.pages.update(slug), data)
+    },
     store: {
       update: (data) => apiClient.put(API_ENDPOINTS.admin.settings.store.update, data)
     }

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -12,7 +12,8 @@ export const API_ENDPOINTS = {
     products: (id) => `/api/collections/${id}/products`
   },
   storefront: {
-    theme: '/api/storefront/theme'
+    theme: '/api/storefront/theme',
+    page: (slug) => `/api/storefront/pages/${slug}`
   },
   storeSettings: {
     get: '/api/store-settings',
@@ -72,6 +73,10 @@ export const API_ENDPOINTS = {
         get: '/api/admin/storefront/theme',
         update: '/api/admin/storefront/theme',
         reset: '/api/admin/storefront/theme'
+      },
+      pages: {
+        get: (slug) => `/api/admin/storefront/pages/${slug}`,
+        update: (slug) => `/api/admin/storefront/pages/${slug}`
       },
       store: {
         update: '/api/admin/store-settings'

--- a/src/api/storefront.js
+++ b/src/api/storefront.js
@@ -7,6 +7,7 @@ export const storefrontAPI = {
    * Get storefront theme
    */
   getTheme: () => apiClient.get(API_ENDPOINTS.storefront.theme),
+  getPage: (slug) => apiClient.get(API_ENDPOINTS.storefront.page(slug)),
 
   /**
    * Get store settings

--- a/src/components/admin/PuckPageEditor.jsx
+++ b/src/components/admin/PuckPageEditor.jsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Puck } from '@puckeditor/core'
+import '@puckeditor/core/puck.css'
+import { adminApiRequest } from '../../lib/auth'
+import { createPageBuilderConfig } from '../storefront/page-builder/config'
+
+const PAGE_OPTIONS = [
+  { slug: 'home', label: 'Home', path: '/' },
+  { slug: 'about', label: 'About', path: '/about' },
+]
+
+const MOCK_PRODUCTS = [
+  {
+    id: 'mock-1',
+    name: 'Premium Headphones',
+    tagline: 'High-fidelity wireless audio',
+    description: 'High-fidelity wireless headphones with noise cancellation.',
+    price: 29900,
+    currency: 'USD',
+    imageUrl: 'https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=500&q=80',
+    stripePriceId: 'price_mock',
+  },
+  {
+    id: 'mock-2',
+    name: 'Ergonomic Chair',
+    tagline: 'Comfort for your workspace',
+    description: 'Designed for comfort and productivity during long work sessions.',
+    price: 45000,
+    currency: 'USD',
+    imageUrl: 'https://images.unsplash.com/photo-1592078615290-033ee584e267?w=500&q=80',
+    stripePriceId: 'price_mock',
+  },
+  {
+    id: 'mock-3',
+    name: 'Mechanical Keyboard',
+    tagline: 'Tactile typing experience',
+    description: 'Tactile switches and customizable RGB lighting.',
+    price: 12000,
+    currency: 'USD',
+    imageUrl: 'https://images.unsplash.com/photo-1587829741301-dc798b91a91e?w=500&q=80',
+    stripePriceId: 'price_mock',
+  },
+]
+
+const MOCK_COLLECTIONS = [
+  { id: 'featured', name: 'Featured' },
+  { id: 'workspace', name: 'Workspace' },
+  { id: 'audio', name: 'Audio' },
+]
+
+export function PuckPageEditor() {
+  const [activeSlug, setActiveSlug] = useState('home')
+  const [page, setPage] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [publishing, setPublishing] = useState(false)
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+
+  const activePage = PAGE_OPTIONS.find((option) => option.slug === activeSlug) || PAGE_OPTIONS[0]
+  const config = useMemo(() => createPageBuilderConfig({
+    products: MOCK_PRODUCTS,
+    collections: MOCK_COLLECTIONS,
+    disableNavigation: true,
+  }), [])
+
+  useEffect(() => {
+    let isMounted = true
+
+    async function loadPage() {
+      try {
+        setLoading(true)
+        setError('')
+        setMessage('')
+        const response = await adminApiRequest(`/api/admin/storefront/pages/${activeSlug}`)
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}))
+          throw new Error(errorData.error || 'Failed to load page')
+        }
+        const data = await response.json()
+        if (isMounted) setPage(data)
+      } catch (loadError) {
+        if (isMounted) setError(loadError.message || 'Failed to load page')
+      } finally {
+        if (isMounted) setLoading(false)
+      }
+    }
+
+    loadPage()
+
+    return () => {
+      isMounted = false
+    }
+  }, [activeSlug])
+
+  const publishPage = async (data) => {
+    try {
+      setPublishing(true)
+      setError('')
+      setMessage('')
+      const response = await adminApiRequest(`/api/admin/storefront/pages/${activeSlug}`, {
+        method: 'PUT',
+        body: JSON.stringify({ data }),
+      })
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(errorData.error || 'Failed to publish page')
+      }
+      const updated = await response.json()
+      setPage(updated)
+      setMessage(`${activePage.label} page published.`)
+    } catch (publishError) {
+      setError(publishError.message || 'Failed to publish page')
+      throw publishError
+    } finally {
+      setPublishing(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-[var(--admin-border-primary)] bg-[var(--admin-bg-card)] p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-base font-semibold text-[var(--admin-text-primary)]">Pages</h3>
+            <p className="text-xs text-[var(--admin-text-muted)]">Edit the Home and About page layouts with reusable storefront blocks.</p>
+          </div>
+          <div className="inline-flex rounded-md border border-[var(--admin-border-primary)] bg-[var(--admin-bg-elevated)] p-1">
+            {PAGE_OPTIONS.map((option) => (
+              <button
+                key={option.slug}
+                type="button"
+                onClick={() => setActiveSlug(option.slug)}
+                className={`h-8 rounded px-3 text-xs font-medium ${activeSlug === option.slug ? 'bg-[var(--admin-accent)] text-white' : 'text-[var(--admin-text-secondary)] hover:text-[var(--admin-text-primary)]'}`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        {(message || error || publishing) && (
+          <div className={`mt-3 rounded-md px-3 py-2 text-xs ${error ? 'bg-[var(--admin-error-bg)] text-[var(--admin-error)]' : 'bg-[var(--admin-success-bg)] text-[var(--admin-success)]'}`}>
+            {error || (publishing ? 'Publishing...' : message)}
+          </div>
+        )}
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-[var(--admin-border-primary)] bg-white">
+        {loading ? (
+          <div className="flex h-96 items-center justify-center text-sm text-[var(--admin-text-muted)]">Loading editor...</div>
+        ) : page?.data ? (
+          <div className="h-[calc(100vh-12rem)] min-h-[720px]">
+            <Puck
+              key={`${activeSlug}-${page.updatedAt || 'default'}`}
+              config={config}
+              data={page.data}
+              headerTitle={`${activePage.label} page`}
+              headerPath={activePage.path}
+              height="100%"
+              onPublish={publishPage}
+              viewports={[
+                { width: 390, height: 'auto', icon: 'Smartphone', label: 'Mobile' },
+                { width: 768, height: 'auto', icon: 'Tablet', label: 'Tablet' },
+                { width: 1280, height: 'auto', icon: 'Monitor', label: 'Desktop' },
+              ]}
+            />
+          </div>
+        ) : (
+          <div className="flex h-96 items-center justify-center text-sm text-[var(--admin-error)]">Page data unavailable.</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/StoreSettingsEditor.jsx
+++ b/src/components/admin/StoreSettingsEditor.jsx
@@ -1,10 +1,9 @@
-import { useState, useEffect, useMemo } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import { Input } from '../ui/input'
 import { Button } from '../ui/button'
 import { Select } from '../ui/select'
 import { Switch } from '../ui/switch'
 import { adminApiRequest } from '../../lib/auth'
-import { normalizeImageUrl } from '../../lib/utils'
 import ImageUrlField from './ImageUrlField'
 import { FONT_OPTIONS, resolveStorefrontTheme, BASE_RADIUS_PX } from '../../lib/theme'
 import {
@@ -21,88 +20,45 @@ import {
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogAction,
-  AlertDialogCancel
+  AlertDialogCancel,
 } from '../ui/alert-dialog'
-import { Navbar } from '../../components/storefront/Navbar'
-import { Hero } from '../../components/storefront/Hero'
-import { ProductCard } from '../../components/storefront/ProductCard'
-import { Carousel } from '../../components/storefront/Carousel'
-import { Footer } from '../../components/storefront/Footer'
-import { Paintbrush, Type, Layout, Image as ImageIcon, Info, MapPin, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import { Image as ImageIcon, Info, MapPin, Paintbrush } from 'lucide-react'
 
-const MOCK_PRODUCTS = [
-  {
-    id: 'mock-1',
-    name: 'Premium Headphones',
-    tagline: 'High-fidelity wireless audio',
-    description: 'High-fidelity wireless headphones with noise cancellation.',
-    price: 29900,
-    currency: 'USD',
-    imageUrl: 'https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=500&q=80',
-    stripePriceId: 'price_mock'
-  },
-  {
-    id: 'mock-2',
-    name: 'Ergonomic Chair',
-    tagline: 'Comfort for your workspace',
-    description: 'Designed for comfort and productivity during long work sessions.',
-    price: 45000,
-    currency: 'USD',
-    imageUrl: 'https://images.unsplash.com/photo-1592078615290-033ee584e267?w=500&q=80',
-    stripePriceId: 'price_mock'
-  },
-  {
-    id: 'mock-3',
-    name: 'Mechanical Keyboard',
-    tagline: 'Tactile typing experience',
-    description: 'Tactile switches and customizable RGB lighting.',
-    price: 12000,
-    currency: 'USD',
-    imageUrl: 'https://images.unsplash.com/photo-1587829741301-dc798b91a91e?w=500&q=80',
-    stripePriceId: 'price_mock'
-  }
-]
+const PuckPageEditor = lazy(() => import('./PuckPageEditor').then((module) => ({ default: module.PuckPageEditor })))
 
-const MOCK_COLLECTIONS = [
-  { id: 'featured', name: 'Featured' },
-  { id: 'workspace', name: 'Workspace' },
-  { id: 'audio', name: 'Audio' },
-]
+const DEFAULT_SETTINGS = {
+  logoType: 'text',
+  logoText: 'OpenShop',
+  logoImageUrl: '',
+  storeName: 'OpenShop',
+  storeDescription: 'Your amazing online store',
+  heroImageUrl: '',
+  heroTitle: 'Welcome to OpenShop',
+  heroSubtitle: 'Discover amazing products at unbeatable prices. Built on Cloudflare for lightning-fast performance.',
+  aboutHeroImageUrl: '',
+  aboutHeroTitle: 'About Us',
+  aboutHeroSubtitle: 'Learn more about our story and mission',
+  aboutContent: 'Welcome to our store! We are passionate about providing high-quality products and exceptional customer service.',
+  contactEmail: 'contact@example.com',
+  businessName: '',
+  businessAddressLine1: '',
+  businessAddressLine2: '',
+  businessCity: '',
+  businessState: '',
+  businessPostalCode: '',
+  businessCountry: '',
+}
 
 export function StoreSettingsEditor() {
+  const [activeTab, setActiveTab] = useState('settings')
   const [activeSection, setActiveSection] = useState('theme')
-  const [previewPage, setPreviewPage] = useState('home')
-  const [editorCollapsed, setEditorCollapsed] = useState(false)
-  const [settings, setSettings] = useState({
-    logoType: 'text',
-    logoText: 'OpenShop',
-    logoImageUrl: '',
-    storeName: 'OpenShop',
-    storeDescription: 'Your amazing online store',
-    heroImageUrl: '',
-    heroTitle: 'Welcome to OpenShop',
-    heroSubtitle: 'Discover amazing products at unbeatable prices. Built on Cloudflare for lightning-fast performance.',
-    aboutHeroImageUrl: '',
-    aboutHeroTitle: 'About Us',
-    aboutHeroSubtitle: 'Learn more about our story and mission',
-    aboutContent: 'Welcome to our store! We are passionate about providing high-quality products and exceptional customer service. Our journey began with a simple idea: to make great products accessible to everyone.\n\nWe believe in quality, sustainability, and building lasting relationships with our customers. Every product in our catalog is carefully selected to meet our high standards.\n\nThank you for choosing us for your shopping needs!',
-    contactEmail: 'contact@example.com',
-    businessName: '',
-    businessAddressLine1: '',
-    businessAddressLine2: '',
-    businessCity: '',
-    businessState: '',
-    businessPostalCode: '',
-    businessCountry: ''
-  })
+  const [settings, setSettings] = useState(DEFAULT_SETTINGS)
   const [settingsBaseline, setSettingsBaseline] = useState(null)
   const [saving, setSaving] = useState(false)
   const [modalImage, setModalImage] = useState(null)
   const [savedOpen, setSavedOpen] = useState(false)
   const [errorOpen, setErrorOpen] = useState(false)
   const [errorText, setErrorText] = useState('')
-  const [driveNotice, setDriveNotice] = useState('')
-  const [driveNoticeTimer, setDriveNoticeTimer] = useState(null)
 
   const [themeState, setThemeState] = useState(createThemeState())
   const [themeLoading, setThemeLoading] = useState(true)
@@ -114,22 +70,38 @@ export function StoreSettingsEditor() {
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false)
 
   const previewTheme = useMemo(() => resolveStorefrontTheme(themeState), [themeState])
-  const previewStyles = useMemo(() => ({ ...previewTheme.cssVariables }), [previewTheme])
-  const settingsDirty = useMemo(
-    () => JSON.stringify(settings) !== JSON.stringify(settingsBaseline || settings),
-    [settings, settingsBaseline]
-  )
   const selectedFontOption = useMemo(
     () => FONT_OPTIONS.find((font) => font.id === themeState.typography.fontId) || FONT_OPTIONS[0],
     [themeState.typography.fontId]
   )
-
   const computedRadiusPx = Math.round(previewTheme.corners.radiusPx || 0)
+  const settingsDirty = useMemo(
+    () => JSON.stringify(settings) !== JSON.stringify(settingsBaseline || settings),
+    [settings, settingsBaseline]
+  )
 
   useEffect(() => {
     fetchSettings()
     fetchTheme()
   }, [])
+
+  const fetchSettings = async () => {
+    try {
+      const response = await adminApiRequest('/api/admin/store-settings')
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(errorData.error || 'Failed to load store settings')
+      }
+      const data = await response.json()
+      const nextSettings = { ...DEFAULT_SETTINGS, ...data }
+      setSettings(nextSettings)
+      setSettingsBaseline(nextSettings)
+    } catch (error) {
+      console.error('Error fetching store settings:', error)
+      setErrorText(error.message || 'Failed to load store settings')
+      setErrorOpen(true)
+    }
+  }
 
   const fetchTheme = async () => {
     try {
@@ -141,8 +113,7 @@ export function StoreSettingsEditor() {
       }
       const data = await response.json()
       const resolved = resolveStorefrontTheme(data)
-      const nextState = extractThemeState(resolved)
-      setThemeState(nextState)
+      setThemeState(extractThemeState(resolved))
       setThemeHasOverrides(Boolean(resolved.meta?.updatedAt))
       setThemeDirty(false)
       setThemeMessage('')
@@ -155,66 +126,9 @@ export function StoreSettingsEditor() {
     }
   }
 
-  const fetchSettings = async () => {
-    try {
-      const response = await fetch('/api/store-settings')
-      if (response.ok) {
-        const data = await response.json()
-        setSettings(prev => {
-          const nextSettings = {
-            ...prev,
-            ...data,
-            // Ensure about page fields have defaults if missing
-            aboutHeroImageUrl: data.aboutHeroImageUrl || '',
-            aboutHeroTitle: data.aboutHeroTitle || prev.aboutHeroTitle,
-            aboutHeroSubtitle: data.aboutHeroSubtitle || prev.aboutHeroSubtitle,
-            aboutContent: data.aboutContent || prev.aboutContent || ''
-          }
-          setSettingsBaseline(nextSettings)
-          return nextSettings
-        })
-      }
-    } catch (error) {
-      console.error('Error fetching store settings:', error)
-    }
-  }
-
-  const handleChange = (e) => {
-    const { name, value } = e.target
-    const shouldNormalize = name === 'logoImageUrl' || name === 'heroImageUrl' || name === 'aboutHeroImageUrl'
-    const normalized = shouldNormalize ? maybeNormalizeDriveUrl(value) : value
-    setSettings(prev => ({
-      ...prev,
-      [name]: normalized
-    }))
-  }
-
-  const handleLogoTypeChange = (e) => {
-    const logoType = e.target.value
-    setSettings(prev => ({
-      ...prev,
-      logoType
-    }))
-  }
-
-  function maybeNormalizeDriveUrl(input) {
-    const val = (input || '').trim()
-    if (!val) return input
-    const isDrive = val.includes('drive.google.com') || val.includes('drive.usercontent.google.com')
-    if (!isDrive) return input
-    const fileMatch = val.match(/\/file\/d\/([a-zA-Z0-9_-]+)/)
-    const idMatch = val.match(/[?&#]id=([a-zA-Z0-9_-]+)/)
-    const id = (fileMatch && fileMatch[1]) || (idMatch && idMatch[1]) || null
-    const normalized = id
-      ? `https://drive.usercontent.google.com/download?id=${id}&export=view`
-      : val
-    if (normalized !== val) {
-      setDriveNotice('Google Drive link detected - converted for reliable preview and delivery.')
-      if (driveNoticeTimer) clearTimeout(driveNoticeTimer)
-      const t = setTimeout(() => setDriveNotice(''), 3000)
-      setDriveNoticeTimer(t)
-    }
-    return normalized
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setSettings((prev) => ({ ...prev, [name]: value }))
   }
 
   const markThemeDirty = () => {
@@ -260,41 +174,31 @@ export function StoreSettingsEditor() {
   const handleThemeCornerMultiplierChange = (value) => {
     const numeric = Number(value)
     if (Number.isNaN(numeric)) return
-    const clamped = Math.min(Math.max(numeric, 0), 4)
     setThemeState((prev) => ({
       ...prev,
       corners: {
         ...prev.corners,
-        radiusMultiplier: clamped,
+        radiusMultiplier: Math.min(Math.max(numeric, 0), 4),
       },
     }))
     markThemeDirty()
   }
 
   const persistTheme = async () => {
-    try {
-      setThemeError('')
-      setThemeMessage('')
-      const response = await adminApiRequest('/api/admin/storefront/theme', {
-        method: 'PUT',
-        body: JSON.stringify(themeState),
-      })
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}))
-        throw new Error(errorData.error || 'Failed to update storefront theme')
-      }
-      const data = await response.json()
-      const resolved = resolveStorefrontTheme(data)
-      setThemeState(extractThemeState(resolved))
-      setThemeHasOverrides(Boolean(resolved.meta?.updatedAt ?? Date.now()))
-      setThemeDirty(false)
-      setThemeMessage('Theme settings saved.')
-      return resolved
-    } catch (error) {
-      console.error('Error updating storefront theme:', error)
-      setThemeError(error.message || 'Failed to save theme')
-      throw error
+    const response = await adminApiRequest('/api/admin/storefront/theme', {
+      method: 'PUT',
+      body: JSON.stringify(themeState),
+    })
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new Error(errorData.error || 'Failed to update storefront theme')
     }
+    const data = await response.json()
+    const resolved = resolveStorefrontTheme(data)
+    setThemeState(extractThemeState(resolved))
+    setThemeHasOverrides(Boolean(resolved.meta?.updatedAt ?? Date.now()))
+    setThemeDirty(false)
+    setThemeMessage('Theme settings saved.')
   }
 
   const handleThemeReset = async () => {
@@ -316,7 +220,6 @@ export function StoreSettingsEditor() {
       setThemeMessage('Theme reset to defaults.')
       return true
     } catch (error) {
-      console.error('Error resetting storefront theme:', error)
       setThemeError(error.message || 'Failed to reset theme')
       return false
     } finally {
@@ -326,36 +229,35 @@ export function StoreSettingsEditor() {
 
   const confirmThemeReset = async () => {
     const result = await handleThemeReset()
-    if (result) {
-      setResetConfirmOpen(false)
-    }
+    if (result) setResetConfirmOpen(false)
   }
 
-  const handleSubmit = async (e) => {
-    if (e) {
-      e.preventDefault()
-    }
+  const handleSubmit = async (event) => {
+    event.preventDefault()
     setSaving(true)
+    setThemeError('')
+    setThemeMessage('')
 
     try {
       if (!themeLoading && themeDirty) {
         await persistTheme()
       }
 
-      const response = await adminApiRequest('/api/admin/store-settings', {
-        method: 'PUT',
-        body: JSON.stringify(settings),
-      })
-
-      if (response.ok) {
+      if (settingsDirty) {
+        const response = await adminApiRequest('/api/admin/store-settings', {
+          method: 'PUT',
+          body: JSON.stringify(settings),
+        })
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}))
+          throw new Error(errorData.error || 'Failed to update settings')
+        }
         const updatedSettings = await response.json()
-        setSettings(updatedSettings)
-        setSettingsBaseline(updatedSettings)
-        setSavedOpen(true)
-      } else {
-        const error = await response.json()
-        throw new Error(error.error || 'Failed to update settings')
+        setSettings({ ...DEFAULT_SETTINGS, ...updatedSettings })
+        setSettingsBaseline({ ...DEFAULT_SETTINGS, ...updatedSettings })
       }
+
+      setSavedOpen(true)
     } catch (error) {
       console.error('Error saving store settings:', error)
       setErrorText('Error saving settings: ' + (error?.message || 'Unknown error'))
@@ -365,87 +267,78 @@ export function StoreSettingsEditor() {
     }
   }
 
-  const menuItems = [
+  const sections = [
     { id: 'theme', label: 'Theme & Colors', icon: Paintbrush },
     { id: 'identity', label: 'Identity', icon: ImageIcon },
     { id: 'info', label: 'Store Info', icon: Info },
-    { id: 'hero', label: 'Homepage Hero', icon: Layout },
-    { id: 'about', label: 'About Page', icon: Type },
     { id: 'contact', label: 'Contact & Business', icon: MapPin },
   ]
 
   return (
     <div className="space-y-4">
       <div className="rounded-xl border border-[var(--admin-border-primary)] bg-[var(--admin-bg-card)] p-4 shadow-sm">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h2 className="text-lg font-semibold text-[var(--admin-text-primary)]">Store settings</h2>
-            <p className="text-xs text-[var(--admin-text-muted)]">Edit content on the left and compare with a storefront-accurate preview.</p>
+            <p className="text-xs text-[var(--admin-text-muted)]">Manage brand settings and edit storefront pages.</p>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="inline-flex rounded-md border border-[var(--admin-border-primary)] bg-[var(--admin-bg-elevated)] p-1">
-              <Button type="button" size="sm" variant={previewPage === 'home' ? 'default' : 'ghost'} onClick={() => setPreviewPage('home')} className="h-8 px-3 text-xs">
-                Homepage
-              </Button>
-              <Button type="button" size="sm" variant={previewPage === 'about' ? 'default' : 'ghost'} onClick={() => setPreviewPage('about')} className="h-8 px-3 text-xs">
-                About page
-              </Button>
-            </div>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              onClick={() => setEditorCollapsed((prev) => !prev)}
-              className="h-8 px-3 text-xs"
-            >
-              {editorCollapsed ? <PanelLeftOpen className="mr-1.5 h-3.5 w-3.5" /> : <PanelLeftClose className="mr-1.5 h-3.5 w-3.5" />}
-              {editorCollapsed ? 'Show editor' : 'Collapse editor'}
+          <div className="inline-flex rounded-md border border-[var(--admin-border-primary)] bg-[var(--admin-bg-elevated)] p-1">
+            <Button type="button" size="sm" variant={activeTab === 'settings' ? 'default' : 'ghost'} onClick={() => setActiveTab('settings')} className="h-8 px-3 text-xs">
+              Brand & Theme
+            </Button>
+            <Button type="button" size="sm" variant={activeTab === 'pages' ? 'default' : 'ghost'} onClick={() => setActiveTab('pages')} className="h-8 px-3 text-xs">
+              Pages
             </Button>
           </div>
         </div>
       </div>
 
-      <div className={`grid gap-4 ${editorCollapsed ? "" : "xl:grid-cols-[360px_minmax(0,1fr)]"}`}>
-        {!editorCollapsed && (
-        <div className="rounded-xl border border-[var(--admin-border-primary)] bg-[var(--admin-bg-secondary)] p-4 shadow-sm space-y-4">
-          <div className="grid grid-cols-2 gap-2">
-            {menuItems.map((item) => {
-              const Icon = item.icon
-              return (
-                <button
-                  key={item.id}
-                  type="button"
-                  onClick={() => setActiveSection(item.id)}
-                  className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors ${
-                    activeSection === item.id
-                      ? 'border-[var(--admin-accent)] bg-[var(--admin-accent)]/15 text-[var(--admin-accent-light)]'
-                      : 'border-[var(--admin-border-primary)] text-[var(--admin-text-secondary)] hover:bg-[var(--admin-overlay-light)] hover:text-[var(--admin-text-primary)]'
-                  }`}
-                >
-                  <Icon className="h-3.5 w-3.5" />
-                  <span>{item.label}</span>
-                </button>
-              )
-            })}
+      {activeTab === 'pages' ? (
+        <Suspense fallback={<div className="rounded-lg border border-[var(--admin-border-primary)] bg-[var(--admin-bg-card)] p-6 text-sm text-[var(--admin-text-muted)]">Loading page editor...</div>}>
+          <PuckPageEditor />
+        </Suspense>
+      ) : (
+        <form onSubmit={handleSubmit} className="grid gap-4 xl:grid-cols-[320px_minmax(0,1fr)]">
+          <div className="rounded-xl border border-[var(--admin-border-primary)] bg-[var(--admin-bg-secondary)] p-4 shadow-sm">
+            <div className="grid gap-2">
+              {sections.map((item) => {
+                const Icon = item.icon
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => setActiveSection(item.id)}
+                    className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors ${
+                      activeSection === item.id
+                        ? 'border-[var(--admin-accent)] bg-[var(--admin-accent)]/15 text-[var(--admin-accent-light)]'
+                        : 'border-[var(--admin-border-primary)] text-[var(--admin-text-secondary)] hover:bg-[var(--admin-overlay-light)] hover:text-[var(--admin-text-primary)]'
+                    }`}
+                  >
+                    <Icon className="h-3.5 w-3.5" />
+                    <span>{item.label}</span>
+                  </button>
+                )
+              })}
+            </div>
           </div>
 
-          <div className="space-y-4">
+          <div className="rounded-xl border border-[var(--admin-border-primary)] bg-[var(--admin-bg-card)] p-5 shadow-sm">
             {activeSection === 'theme' && (
               <div className="space-y-6">
-                <div className="flex justify-between items-center">
-                  <h3 className="text-sm font-semibold text-[var(--admin-text-primary)] uppercase tracking-wide">Theme</h3>
-                  <Button variant="outline" size="sm" onClick={() => setResetConfirmOpen(true)} disabled={themeLoading} className="h-8 text-xs">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--admin-text-primary)]">Theme</h3>
+                  <Button type="button" variant="outline" size="sm" onClick={() => setResetConfirmOpen(true)} disabled={themeLoading}>
                     Reset
                   </Button>
                 </div>
 
                 {COLOR_GROUPS.map((group) => (
                   <div key={group.title} className="space-y-3">
-                    <div className="space-y-1">
+                    <div>
                       <h4 className="text-sm font-medium text-[var(--admin-text-primary)]">{group.title}</h4>
                       <p className="text-xs text-[var(--admin-text-muted)]">{group.description}</p>
                     </div>
-                    <div className="grid gap-3">
+                    <div className="grid gap-3 md:grid-cols-2">
                       {group.fields.map((field) => (
                         <div key={field.key} className="space-y-2">
                           <label className="block text-xs font-semibold uppercase text-[var(--admin-text-secondary)]">{field.label}</label>
@@ -454,14 +347,9 @@ export function StoreSettingsEditor() {
                               type="color"
                               value={themeState.colors[field.key]}
                               onChange={(event) => handleThemeColorChange(field.key, event.target.value)}
-                              className="h-8 w-12 rounded border border-[var(--admin-border-primary)] cursor-pointer bg-transparent"
+                              className="h-8 w-12 cursor-pointer rounded border border-[var(--admin-border-primary)] bg-transparent"
                             />
-                            <Input
-                              value={themeState.colors[field.key]}
-                              onChange={(event) => handleThemeColorChange(field.key, event.target.value)}
-                              maxLength={7}
-                              className="h-8 text-xs"
-                            />
+                            <Input value={themeState.colors[field.key]} onChange={(event) => handleThemeColorChange(field.key, event.target.value)} maxLength={7} className="h-8 text-xs" />
                           </div>
                         </div>
                       ))}
@@ -469,34 +357,22 @@ export function StoreSettingsEditor() {
                   </div>
                 ))}
 
-                <div className="space-y-4 pt-4 border-t border-[var(--admin-border-primary)]">
+                <div className="grid gap-4 border-t border-[var(--admin-border-primary)] pt-4 md:grid-cols-2">
                   <div className="space-y-2">
                     <label className="block text-xs font-semibold uppercase text-[var(--admin-text-secondary)]">Typography</label>
                     <Select value={themeState.typography.fontId} onChange={(event) => handleThemeFontChange(event.target.value)}>
-                      {FONT_OPTIONS.map((font) => (
-                        <option key={font.id} value={font.id}>{font.label}</option>
-                      ))}
+                      {FONT_OPTIONS.map((font) => <option key={font.id} value={font.id}>{font.label}</option>)}
                     </Select>
                     <p className="text-xs text-[var(--admin-text-muted)]">Active font: {selectedFontOption.label}</p>
                   </div>
-
                   <div className="space-y-3">
                     <div className="flex items-center justify-between gap-3">
-                      <label className="block text-xs font-semibold uppercase text-[var(--admin-text-secondary)]">Rounded Corners</label>
+                      <label className="block text-xs font-semibold uppercase text-[var(--admin-text-secondary)]">Rounded corners</label>
                       <Switch id="roundedCorners" checked={themeState.corners.enabled} onCheckedChange={handleThemeCornerToggle} />
                     </div>
                     <div className={themeState.corners.enabled ? '' : 'opacity-50'}>
-                      <label className="block text-xs font-semibold uppercase text-[var(--admin-text-secondary)] mb-1">Radius Multiplier ({computedRadiusPx}px)</label>
-                      <Input
-                        type="number"
-                        min="0"
-                        max="4"
-                        step="0.1"
-                        value={themeState.corners.radiusMultiplier}
-                        onChange={(event) => handleThemeCornerMultiplierChange(event.target.value)}
-                        disabled={!themeState.corners.enabled}
-                        className="h-8"
-                      />
+                      <label className="mb-1 block text-xs font-semibold uppercase text-[var(--admin-text-secondary)]">Radius Multiplier ({computedRadiusPx || BASE_RADIUS_PX}px)</label>
+                      <Input type="number" min="0" max="4" step="0.1" value={themeState.corners.radiusMultiplier} onChange={(event) => handleThemeCornerMultiplierChange(event.target.value)} disabled={!themeState.corners.enabled} className="h-8" />
                     </div>
                   </div>
                 </div>
@@ -505,32 +381,23 @@ export function StoreSettingsEditor() {
 
             {activeSection === 'identity' && (
               <div className="space-y-4">
-                <h3 className="text-sm font-semibold text-[var(--admin-text-primary)] uppercase tracking-wide">Brand Identity</h3>
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--admin-text-primary)]">Brand Identity</h3>
                 <div>
-                  <label className="block text-sm font-medium mb-2">Logo Type</label>
-                  <Select name="logoType" value={settings.logoType} onChange={handleLogoTypeChange}>
+                  <label className="mb-2 block text-sm font-medium">Logo Type</label>
+                  <Select name="logoType" value={settings.logoType} onChange={handleChange}>
                     <option value="text">Text Logo</option>
                     <option value="image">Image Logo</option>
                   </Select>
                 </div>
-
                 {settings.logoType === 'text' ? (
                   <div>
-                    <label className="block text-sm font-medium mb-2">Logo Text</label>
-                    <Input name="logoText" value={settings.logoText} onChange={handleChange} placeholder="Enter your store name" />
+                    <label className="mb-2 block text-sm font-medium">Logo Text</label>
+                    <Input name="logoText" value={settings.logoText} onChange={handleChange} />
                   </div>
                 ) : (
-                  <div className="space-y-2">
-                    <label className="block text-sm font-medium">Logo Image URL</label>
-                    <ImageUrlField
-                      value={settings.logoImageUrl}
-                      onChange={(val) => setSettings((prev) => ({ ...prev, logoImageUrl: val }))}
-                      placeholder="https://example.com/logo.png"
-                      onPreview={(src) => setModalImage(src)}
-                      hideInput
-                    />
-                    {driveNotice && <p className="text-xs text-[var(--admin-text-secondary)]">{driveNotice}</p>}
-                    <p className="text-xs text-[var(--admin-text-muted)]">Recommended size: 200x50px</p>
+                  <div>
+                    <label className="mb-2 block text-sm font-medium">Logo Image</label>
+                    <ImageUrlField value={settings.logoImageUrl} onChange={(value) => setSettings((prev) => ({ ...prev, logoImageUrl: value }))} onPreview={(src) => setModalImage(src)} hideInput />
                   </div>
                 )}
               </div>
@@ -538,241 +405,99 @@ export function StoreSettingsEditor() {
 
             {activeSection === 'info' && (
               <div className="space-y-4">
-                <h3 className="text-sm font-semibold text-[var(--admin-text-primary)] uppercase tracking-wide">Store Info</h3>
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--admin-text-primary)]">Store Info</h3>
                 <div>
-                  <label className="block text-sm font-medium mb-2">Store Name</label>
-                  <Input name="storeName" value={settings.storeName} onChange={handleChange} placeholder="Your Store Name" />
+                  <label className="mb-2 block text-sm font-medium">Store Name</label>
+                  <Input name="storeName" value={settings.storeName} onChange={handleChange} />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium mb-2">Store Description</label>
-                  <Input name="storeDescription" value={settings.storeDescription} onChange={handleChange} placeholder="Brief description of your store" />
-                </div>
-              </div>
-            )}
-
-            {activeSection === 'hero' && (
-              <div className="space-y-4">
-                <h3 className="text-sm font-semibold text-[var(--admin-text-primary)] uppercase tracking-wide">Homepage Hero</h3>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Hero Image URL</label>
-                  <ImageUrlField
-                    value={settings.heroImageUrl}
-                    onChange={(val) => setSettings((prev) => ({ ...prev, heroImageUrl: val }))}
-                    placeholder="https://example.com/hero.jpg"
-                    onPreview={(src) => setModalImage(src)}
-                    hideInput
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Hero Title (H1)</label>
-                  <Input name="heroTitle" value={settings.heroTitle} onChange={handleChange} placeholder="Welcome" />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Hero Subtitle (H2)</label>
-                  <Input name="heroSubtitle" value={settings.heroSubtitle} onChange={handleChange} placeholder="Subtitle" />
-                </div>
-              </div>
-            )}
-
-            {activeSection === 'about' && (
-              <div className="space-y-4">
-                <h3 className="text-sm font-semibold text-[var(--admin-text-primary)] uppercase tracking-wide">About Page</h3>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Hero Image URL</label>
-                  <ImageUrlField
-                    value={settings.aboutHeroImageUrl}
-                    onChange={(val) => setSettings((prev) => ({ ...prev, aboutHeroImageUrl: val }))}
-                    placeholder="https://example.com/about-hero.jpg"
-                    onPreview={(src) => setModalImage(src)}
-                    hideInput
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Hero Title</label>
-                  <Input name="aboutHeroTitle" value={settings.aboutHeroTitle} onChange={handleChange} />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Hero Subtitle</label>
-                  <Input name="aboutHeroSubtitle" value={settings.aboutHeroSubtitle} onChange={handleChange} />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-2">Content</label>
-                  <textarea
-                    name="aboutContent"
-                    value={settings.aboutContent}
-                    onChange={handleChange}
-                    rows={8}
-                    className="w-full px-3 py-2 border border-[var(--admin-border-primary)] rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--admin-accent)] focus:border-transparent text-sm bg-[var(--admin-bg-elevated)] text-[var(--admin-text-primary)]"
-                  />
+                  <label className="mb-2 block text-sm font-medium">Store Description</label>
+                  <Input name="storeDescription" value={settings.storeDescription} onChange={handleChange} />
                 </div>
               </div>
             )}
 
             {activeSection === 'contact' && (
               <div className="space-y-4">
-                <h3 className="text-sm font-semibold text-[var(--admin-text-primary)] uppercase tracking-wide">Contact & Business</h3>
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--admin-text-primary)]">Contact & Business</h3>
                 <div>
-                  <label className="block text-sm font-medium mb-2">Contact Email</label>
-                  <Input type="email" name="contactEmail" value={settings.contactEmail} onChange={handleChange} placeholder="contact@yourstore.com" />
+                  <label className="mb-2 block text-sm font-medium">Contact Email</label>
+                  <Input type="email" name="contactEmail" value={settings.contactEmail} onChange={handleChange} />
                 </div>
-                <div className="pt-4 border-t space-y-4">
-                  <h4 className="text-sm font-medium text-[var(--admin-text-primary)]">Business Address</h4>
+                <div className="grid gap-3 border-t border-[var(--admin-border-primary)] pt-4 md:grid-cols-2">
                   <Input name="businessName" value={settings.businessName || ''} onChange={handleChange} placeholder="Business Name" />
                   <Input name="businessAddressLine1" value={settings.businessAddressLine1 || ''} onChange={handleChange} placeholder="Address Line 1" />
                   <Input name="businessAddressLine2" value={settings.businessAddressLine2 || ''} onChange={handleChange} placeholder="Address Line 2" />
-                  <div className="grid grid-cols-2 gap-2">
-                    <Input name="businessCity" value={settings.businessCity || ''} onChange={handleChange} placeholder="City" />
-                    <Input name="businessState" value={settings.businessState || ''} onChange={handleChange} placeholder="State" />
-                  </div>
-                  <div className="grid grid-cols-2 gap-2">
-                    <Input name="businessPostalCode" value={settings.businessPostalCode || ''} onChange={handleChange} placeholder="Zip Code" />
-                    <Input name="businessCountry" value={settings.businessCountry || ''} onChange={handleChange} placeholder="Country" />
-                  </div>
+                  <Input name="businessCity" value={settings.businessCity || ''} onChange={handleChange} placeholder="City" />
+                  <Input name="businessState" value={settings.businessState || ''} onChange={handleChange} placeholder="State" />
+                  <Input name="businessPostalCode" value={settings.businessPostalCode || ''} onChange={handleChange} placeholder="Postal Code" />
+                  <Input name="businessCountry" value={settings.businessCountry || ''} onChange={handleChange} placeholder="Country" />
                 </div>
               </div>
             )}
-          </div>
 
-          {(themeMessage || themeError) && (
-            <div className={`rounded-md px-3 py-2 text-xs ${themeError ? 'bg-[var(--admin-error-bg)] text-[var(--admin-error)]' : 'bg-[var(--admin-success-bg)] text-[var(--admin-success)]'}`}>
-              {themeError || themeMessage}
-            </div>
-          )}
+            {(themeMessage || themeError) && (
+              <div className={`mt-5 rounded-md px-3 py-2 text-xs ${themeError ? 'bg-[var(--admin-error-bg)] text-[var(--admin-error)]' : 'bg-[var(--admin-success-bg)] text-[var(--admin-success)]'}`}>
+                {themeError || themeMessage}
+              </div>
+            )}
 
-          <div className="flex items-center justify-between border-t border-[var(--admin-border-primary)] pt-4">
-            <span className="text-xs text-[var(--admin-text-muted)]">
-              {settingsDirty || themeDirty
-                ? 'Unsaved changes'
-                : themeHasOverrides
-                  ? 'Custom theme saved'
-                  : 'Using default theme'}
-            </span>
-            <Button onClick={handleSubmit} disabled={saving || themeSaving || (!settingsDirty && !themeDirty)}>
-              {saving || themeSaving
-                ? 'Saving...'
-                : settingsDirty && themeDirty
-                  ? 'Save all changes'
-                  : themeDirty
-                    ? 'Save theme'
-                    : 'Save settings'}
-            </Button>
-          </div>
-        </div>
-        )}
-
-        <div className="rounded-xl border border-[var(--admin-border-primary)] bg-[var(--admin-bg-card)] p-3 shadow-sm">
-          <div className="max-h-[calc(100vh-10rem)] overflow-auto rounded-lg border border-[var(--admin-border-primary)] bg-white">
-            <div style={previewStyles} data-storefront-theme="true" className="storefront-surface min-h-[900px]">
-              {previewPage === 'home' ? (
-                <>
-                  <Navbar previewSettings={settings} disableNavigation={true} />
-                  <Hero previewSettings={settings} />
-                  <section className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-                    <h2 className="text-3xl font-bold storefront-heading mb-8 text-center">Featured Products</h2>
-                    <Carousel products={MOCK_PRODUCTS} />
-                  </section>
-                  <section className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-                    <div className="flex flex-wrap gap-4 justify-center">
-                      <Button variant="default">All Products</Button>
-                      {MOCK_COLLECTIONS.map((collection) => (
-                        <Button key={collection.id} variant="outline">{collection.name}</Button>
-                      ))}
-                    </div>
-                  </section>
-                  <section className="max-w-8xl mx-auto px-3 sm:px-4 lg:px-6 pb-16">
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6">
-                      {[...MOCK_PRODUCTS, ...MOCK_PRODUCTS].map((product, index) => (
-                        <ProductCard key={`${product.id}-${index}`} product={{ ...product, id: `${product.id}-${index}` }} disableNavigation={true} />
-                      ))}
-                    </div>
-                  </section>
-                  <Footer previewSettings={settings} />
-                </>
-              ) : (
-                <>
-                  <Navbar previewSettings={settings} disableNavigation={true} />
-                  <section className="relative w-screen overflow-hidden text-white">
-                    {settings.aboutHeroImageUrl ? (
-                      <img src={normalizeImageUrl(settings.aboutHeroImageUrl)} alt="About Hero" className="w-screen h-auto max-h-[90vh] object-contain block mx-auto" />
-                    ) : (
-                      <div className="w-screen min-h-[320px] sm:min-h-[420px] lg:min-h-[560px] bg-gradient-to-r from-slate-600 to-slate-700" />
-                    )}
-                    <div className="absolute inset-0 bg-black/40" aria-hidden />
-                    <div className="absolute inset-0 flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 py-12 text-center">
-                      <div className="max-w-4xl mx-auto space-y-6">
-                        <h1 className="text-4xl md:text-6xl font-bold">{settings.aboutHeroTitle}</h1>
-                        <p className="text-xl md:text-2xl max-w-3xl mx-auto">{settings.aboutHeroSubtitle}</p>
-                      </div>
-                    </div>
-                  </section>
-                  <section className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-                    <div className="bg-white rounded-lg shadow-sm p-8 md:p-12">
-                      <div className="prose prose-lg max-w-none">
-                        {(settings.aboutContent || '').split('\n\n').map((paragraph, index) => (
-                          <p key={index} className="mb-6 text-gray-700 leading-relaxed">{paragraph}</p>
-                        ))}
-                      </div>
-                    </div>
-                  </section>
-                  <Footer previewSettings={settings} />
-                </>
-              )}
+            <div className="mt-6 flex items-center justify-between border-t border-[var(--admin-border-primary)] pt-4">
+              <span className="text-xs text-[var(--admin-text-muted)]">
+                {settingsDirty || themeDirty ? 'Unsaved changes' : themeHasOverrides ? 'Custom theme saved' : 'Settings saved'}
+              </span>
+              <Button type="submit" disabled={saving || themeSaving || (!settingsDirty && !themeDirty)}>
+                {saving || themeSaving ? 'Saving...' : 'Save settings'}
+              </Button>
             </div>
           </div>
-        </div>
-      </div>
+        </form>
+      )}
 
-      {/* Modals */}
       {modalImage && (
-      <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50" onClick={() => setModalImage(null)}>
-        <div className="bg-[var(--admin-bg-card)] rounded-lg shadow-xl max-w-3xl w-full mx-4 border border-[var(--admin-border-primary)]" onClick={(e) => e.stopPropagation()}>
-          <img src={modalImage} alt="preview" className="w-full h-auto object-contain rounded" />
-          <div className="p-3 border-t border-[var(--admin-border-primary)] text-center">
-            <a href={modalImage} target="_blank" rel="noreferrer" className="text-sm text-[var(--admin-accent-light)] hover:underline">Open original</a>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70" onClick={() => setModalImage(null)}>
+          <div className="mx-4 w-full max-w-3xl rounded-lg border border-[var(--admin-border-primary)] bg-[var(--admin-bg-card)] shadow-xl" onClick={(event) => event.stopPropagation()}>
+            <img src={modalImage} alt="preview" className="h-auto w-full rounded object-contain" />
           </div>
         </div>
-      </div>
-    )}
-    <AlertDialog open={resetConfirmOpen} onOpenChange={setResetConfirmOpen}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Reset storefront theme?</AlertDialogTitle>
-          <AlertDialogDescription>
-            Resetting restores the bundled colors, fonts, and corner radius. This action cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={themeSaving}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={confirmThemeReset} disabled={themeSaving}>
-            {themeSaving ? 'Resetting...' : 'Reset Theme'}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-    <AlertDialog open={savedOpen} onOpenChange={setSavedOpen}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Settings saved</AlertDialogTitle>
-          <AlertDialogDescription>
-            Store settings updated successfully.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogAction onClick={() => setSavedOpen(false)}>OK</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-    <AlertDialog open={errorOpen} onOpenChange={setErrorOpen}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Something went wrong</AlertDialogTitle>
-          <AlertDialogDescription>{errorText}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogAction>OK</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+      )}
+
+      <AlertDialog open={resetConfirmOpen} onOpenChange={setResetConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reset storefront theme?</AlertDialogTitle>
+            <AlertDialogDescription>Resetting restores the bundled colors, fonts, and corner radius. This action cannot be undone.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={themeSaving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmThemeReset} disabled={themeSaving}>{themeSaving ? 'Resetting...' : 'Reset Theme'}</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={savedOpen} onOpenChange={setSavedOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Settings saved</AlertDialogTitle>
+            <AlertDialogDescription>Store settings updated successfully.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setSavedOpen(false)}>OK</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={errorOpen} onOpenChange={setErrorOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Something went wrong</AlertDialogTitle>
+            <AlertDialogDescription>{errorText}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setErrorOpen(false)}>OK</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/components/storefront/page-builder/PageBuilderBlocks.jsx
+++ b/src/components/storefront/page-builder/PageBuilderBlocks.jsx
@@ -1,0 +1,188 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { normalizeImageUrl } from '../../../lib/utils'
+import { Carousel } from '../Carousel'
+import { ProductCard } from '../ProductCard'
+
+function StorefrontLink({ to, children, variant = 'primary', disableNavigation }) {
+  if (!to || !children) return null
+
+  const className = variant === 'primary'
+    ? 'storefront-button-primary storefront-radius-sm inline-flex items-center justify-center px-6 py-3 text-sm font-semibold'
+    : 'storefront-button-outline storefront-radius-sm inline-flex items-center justify-center px-6 py-3 text-sm font-semibold bg-white'
+
+  if (disableNavigation) {
+    return <span className={`${className} cursor-default`}>{children}</span>
+  }
+
+  if (to.startsWith('/')) {
+    return <Link to={to} className={className}>{children}</Link>
+  }
+
+  return <a href={to} className={className}>{children}</a>
+}
+
+export function HeroSection({
+  title,
+  subtitle,
+  imageUrl,
+  primaryLabel,
+  primaryPath,
+  secondaryLabel,
+  secondaryPath,
+  disableNavigation,
+}) {
+  return (
+    <section className="relative w-full overflow-hidden storefront-hero">
+      {imageUrl ? (
+        <img
+          src={normalizeImageUrl(imageUrl)}
+          alt=""
+          className="block h-[90vh] w-full object-cover"
+        />
+      ) : (
+        <div className="min-h-[320px] w-full sm:min-h-[420px] lg:min-h-[560px]" style={{ backgroundColor: '#1e293b' }} />
+      )}
+
+      <div className="absolute inset-0 bg-black/35" aria-hidden />
+      <div className="absolute inset-0 flex flex-col items-center justify-center px-4 py-12 text-center text-white sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-4xl space-y-6">
+          <h1 className="text-4xl font-bold md:text-6xl">{title}</h1>
+          {subtitle && <p className="mx-auto max-w-3xl text-xl md:text-2xl">{subtitle}</p>}
+          {(primaryLabel || secondaryLabel) && (
+            <div className="flex flex-col justify-center gap-4 sm:flex-row">
+              <StorefrontLink to={primaryPath} disableNavigation={disableNavigation}>{primaryLabel}</StorefrontLink>
+              <StorefrontLink to={secondaryPath} variant="secondary" disableNavigation={disableNavigation}>{secondaryLabel}</StorefrontLink>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function FeaturedProducts({ heading, maxItems = 3, products = [] }) {
+  const featuredProducts = products.slice(0, Number(maxItems) || 3)
+
+  if (!products.length) return null
+
+  return (
+    <section className="mx-auto max-w-8xl px-4 py-16 sm:px-6 lg:px-8">
+      {heading && <h2 className="mb-8 text-center text-3xl font-bold storefront-heading">{heading}</h2>}
+      <Carousel products={featuredProducts} />
+    </section>
+  )
+}
+
+export function ProductGrid({
+  heading,
+  showCollectionFilter = true,
+  products = [],
+  collections = [],
+  disableNavigation,
+}) {
+  const [selectedCollection, setSelectedCollection] = useState(null)
+  const collectionFilterEnabled = showCollectionFilter === true || showCollectionFilter === 'true'
+  const filteredProducts = useMemo(() => (
+    selectedCollection
+      ? products.filter((product) => product.collectionId === selectedCollection)
+      : products
+  ), [products, selectedCollection])
+
+  return (
+    <section id="products" className="mx-auto max-w-8xl px-3 pb-16 sm:px-4 lg:px-6">
+      {collectionFilterEnabled && collections.length > 0 && (
+        <div className="px-1 py-8 sm:px-2">
+          <div className="flex flex-wrap justify-center gap-4">
+            <button
+              type="button"
+              className={`storefront-radius-sm px-4 py-2 text-sm font-medium ${selectedCollection === null ? 'storefront-button-primary' : 'storefront-button-outline'}`}
+              onClick={() => setSelectedCollection(null)}
+            >
+              All Products
+            </button>
+            {collections.map((collection) => (
+              <button
+                key={collection.id}
+                type="button"
+                className={`storefront-radius-sm px-4 py-2 text-sm font-medium ${selectedCollection === collection.id ? 'storefront-button-primary' : 'storefront-button-outline'}`}
+                onClick={() => setSelectedCollection(collection.id)}
+              >
+                {collection.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {heading && <h2 className="mb-8 text-center text-3xl font-bold storefront-heading">{heading}</h2>}
+
+      {filteredProducts.length === 0 ? (
+        <div className="py-16 text-center">
+          <h3 className="mb-2 text-xl font-semibold storefront-heading">No products found</h3>
+          <p className="storefront-subtle">
+            {selectedCollection ? 'No products in this collection yet.' : 'No products available at the moment.'}
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+          {filteredProducts.map((product) => (
+            <ProductCard key={product.id} product={product} disableNavigation={disableNavigation} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export function RichTextSection({ heading, body }) {
+  const paragraphs = String(body || '').split(/\n{2,}/).filter(Boolean)
+
+  return (
+    <section className="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+      <div className="storefront-card storefront-radius bg-white p-8 shadow-sm md:p-12">
+        {heading && <h2 className="mb-6 text-3xl font-bold storefront-heading">{heading}</h2>}
+        <div className="space-y-6 text-lg leading-relaxed storefront-subtle">
+          {paragraphs.map((paragraph, index) => (
+            <p key={`${paragraph.slice(0, 20)}-${index}`}>{paragraph}</p>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function ImageTextSection({ imageUrl, heading, body, imageAlign = 'left' }) {
+  const imageFirst = imageAlign !== 'right'
+
+  return (
+    <section className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+      <div className="grid items-center gap-10 md:grid-cols-2">
+        {imageFirst && <ImagePanel imageUrl={imageUrl} heading={heading} />}
+        <div className="space-y-5">
+          {heading && <h2 className="text-3xl font-bold storefront-heading">{heading}</h2>}
+          <div className="space-y-4 text-lg leading-relaxed storefront-subtle">
+            {String(body || '').split(/\n{2,}/).filter(Boolean).map((paragraph, index) => (
+              <p key={`${paragraph.slice(0, 20)}-${index}`}>{paragraph}</p>
+            ))}
+          </div>
+        </div>
+        {!imageFirst && <ImagePanel imageUrl={imageUrl} heading={heading} />}
+      </div>
+    </section>
+  )
+}
+
+function ImagePanel({ imageUrl, heading }) {
+  if (!imageUrl) {
+    return <div className="aspect-[4/3] storefront-radius-lg storefront-card-muted" />
+  }
+
+  return (
+    <img
+      src={normalizeImageUrl(imageUrl)}
+      alt={heading || ''}
+      className="aspect-[4/3] w-full object-cover storefront-radius-lg"
+    />
+  )
+}

--- a/src/components/storefront/page-builder/PageRenderer.jsx
+++ b/src/components/storefront/page-builder/PageRenderer.jsx
@@ -1,0 +1,14 @@
+import { Render } from '@puckeditor/core'
+import { createPageBuilderConfig } from './config'
+
+export function PageRenderer({
+  data,
+  products = [],
+  collections = [],
+  disableNavigation = false,
+}) {
+  const config = createPageBuilderConfig({ products, collections, disableNavigation })
+  const renderData = data || { content: [], root: { props: {} } }
+
+  return <Render config={config} data={renderData} />
+}

--- a/src/components/storefront/page-builder/config.jsx
+++ b/src/components/storefront/page-builder/config.jsx
@@ -1,0 +1,123 @@
+import {
+  FeaturedProducts,
+  HeroSection,
+  ImageTextSection,
+  ProductGrid,
+  RichTextSection,
+} from './PageBuilderBlocks'
+
+export function createPageBuilderConfig(options = {}) {
+  const {
+    products = [],
+    collections = [],
+    disableNavigation = false,
+  } = options
+
+  return {
+    components: {
+      HeroSection: {
+        label: 'Hero section',
+        fields: {
+          title: { type: 'text' },
+          subtitle: { type: 'textarea' },
+          imageUrl: { type: 'text' },
+          primaryLabel: { type: 'text' },
+          primaryPath: { type: 'text' },
+          secondaryLabel: { type: 'text' },
+          secondaryPath: { type: 'text' },
+        },
+        defaultProps: {
+          title: 'Welcome to OpenShop',
+          subtitle: 'Discover amazing products at unbeatable prices.',
+          imageUrl: '',
+          primaryLabel: 'Shop Now',
+          primaryPath: '#products',
+          secondaryLabel: 'Learn More',
+          secondaryPath: '/about',
+        },
+        render: (props) => <HeroSection {...props} disableNavigation={disableNavigation} />,
+      },
+      FeaturedProducts: {
+        label: 'Featured products',
+        fields: {
+          heading: { type: 'text' },
+          maxItems: { type: 'number', min: 1, max: 12 },
+        },
+        defaultProps: {
+          heading: 'Featured Products',
+          maxItems: 3,
+        },
+        render: (props) => <FeaturedProducts {...props} products={products} />,
+      },
+      ProductGrid: {
+        label: 'Product grid',
+        fields: {
+          heading: { type: 'text' },
+          showCollectionFilter: {
+            type: 'select',
+            options: [
+              { label: 'Show collection filter', value: true },
+              { label: 'Hide collection filter', value: false },
+            ],
+          },
+        },
+        defaultProps: {
+          heading: 'All Products',
+          showCollectionFilter: true,
+        },
+        render: (props) => (
+          <ProductGrid
+            {...props}
+            products={products}
+            collections={collections}
+            disableNavigation={disableNavigation}
+          />
+        ),
+      },
+      RichTextSection: {
+        label: 'Text section',
+        fields: {
+          heading: { type: 'text' },
+          body: { type: 'textarea' },
+        },
+        defaultProps: {
+          heading: 'About this store',
+          body: 'Write your content here.',
+        },
+        render: (props) => <RichTextSection {...props} />,
+      },
+      ImageTextSection: {
+        label: 'Image and text',
+        fields: {
+          imageUrl: { type: 'text' },
+          heading: { type: 'text' },
+          body: { type: 'textarea' },
+          imageAlign: {
+            type: 'select',
+            options: [
+              { label: 'Image left', value: 'left' },
+              { label: 'Image right', value: 'right' },
+            ],
+          },
+        },
+        defaultProps: {
+          imageUrl: '',
+          heading: 'Section heading',
+          body: 'Add supporting copy here.',
+          imageAlign: 'left',
+        },
+        render: (props) => <ImageTextSection {...props} />,
+      },
+    },
+    categories: {
+      layout: {
+        title: 'Layout',
+        components: ['HeroSection', 'ImageTextSection', 'RichTextSection'],
+      },
+      commerce: {
+        title: 'Commerce',
+        components: ['FeaturedProducts', 'ProductGrid'],
+      },
+    },
+  }
+}

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -47,6 +47,7 @@ export const KV_KEYS = {
   COLLECTIONS_LIST: 'collections:all',
   MEDIA_LIST: 'media:all',
   STORE_SETTINGS: 'store:settings',
+  STOREFRONT_PAGE_PREFIX: 'storefront:page:',
   DRIVE_TOKEN: 'drive:oauth:tokens',
   DRIVE_FOLDER_PREFIX: 'drive:folder',
   ADMIN_TOKEN_PREFIX: 'admin_token:',

--- a/src/lib/pageContent.js
+++ b/src/lib/pageContent.js
@@ -1,0 +1,282 @@
+const PAGE_VERSION = 1
+const MAX_PAGE_BYTES = 50000
+const MAX_TEXT_LENGTH = 5000
+
+export const ALLOWED_PAGE_SLUGS = ['home', 'about']
+
+export const PAGE_COMPONENT_PROPS = {
+  HeroSection: {
+    title: 'string',
+    subtitle: 'string',
+    imageUrl: 'url',
+    primaryLabel: 'string',
+    primaryPath: 'url',
+    secondaryLabel: 'string',
+    secondaryPath: 'url',
+  },
+  FeaturedProducts: {
+    heading: 'string',
+    maxItems: 'number',
+  },
+  ProductGrid: {
+    heading: 'string',
+    showCollectionFilter: 'boolean',
+  },
+  RichTextSection: {
+    heading: 'string',
+    body: 'string',
+  },
+  ImageTextSection: {
+    imageUrl: 'url',
+    heading: 'string',
+    body: 'string',
+    imageAlign: 'enum:left,right',
+  },
+}
+
+export const ALLOWED_PAGE_COMPONENTS = Object.keys(PAGE_COMPONENT_PROPS)
+
+export function getPageContentKey(slug) {
+  assertPageSlug(slug)
+  return `storefront:page:${slug}`
+}
+
+export function assertPageSlug(slug) {
+  if (!ALLOWED_PAGE_SLUGS.includes(slug)) {
+    throw new Error(`Invalid page slug: ${slug}`)
+  }
+}
+
+export function createDefaultPageRecord(slug, settings = {}) {
+  assertPageSlug(slug)
+  const data = slug === 'about'
+    ? createDefaultAboutData(settings)
+    : createDefaultHomeData(settings)
+
+  return {
+    slug,
+    version: PAGE_VERSION,
+    updatedAt: null,
+    data,
+  }
+}
+
+export function createPageRecord(slug, data, now = new Date()) {
+  assertPageSlug(slug)
+  const sanitizedData = validatePageData(data)
+  return {
+    slug,
+    version: PAGE_VERSION,
+    updatedAt: now.toISOString(),
+    data: sanitizedData,
+  }
+}
+
+export function validatePageRecord(record) {
+  if (!record || typeof record !== 'object') {
+    throw new Error('Invalid page record')
+  }
+
+  assertPageSlug(record.slug)
+
+  return {
+    slug: record.slug,
+    version: PAGE_VERSION,
+    updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : null,
+    data: validatePageData(record.data),
+  }
+}
+
+export function validatePageData(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('Page data must be an object')
+  }
+
+  const serialized = JSON.stringify(data)
+  if (serialized.length > MAX_PAGE_BYTES) {
+    throw new Error('Page data is too large')
+  }
+
+  if (!Array.isArray(data.content)) {
+    throw new Error('Page data must include a content array')
+  }
+
+  if (!data.root || typeof data.root !== 'object' || Array.isArray(data.root)) {
+    throw new Error('Page data must include a root object')
+  }
+
+  return {
+    content: data.content.map(validateContentItem),
+    root: {
+      ...data.root,
+      props: sanitizePlainObject(data.root.props || {}),
+    },
+  }
+}
+
+function validateContentItem(item) {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) {
+    throw new Error('Page content entries must be objects')
+  }
+
+  if (!ALLOWED_PAGE_COMPONENTS.includes(item.type)) {
+    throw new Error(`Unsupported page component: ${item.type}`)
+  }
+
+  return {
+    type: item.type,
+    props: sanitizeProps(item.type, item.props || {}),
+  }
+}
+
+function sanitizeProps(type, props) {
+  if (!props || typeof props !== 'object' || Array.isArray(props)) {
+    throw new Error(`${type} props must be an object`)
+  }
+
+  const schema = PAGE_COMPONENT_PROPS[type]
+  const sanitized = {}
+
+  for (const [key, value] of Object.entries(props)) {
+    if (key === 'id') {
+      sanitized.id = sanitizeString(value, 128)
+      continue
+    }
+
+    const expectedType = schema[key]
+    if (!expectedType) continue
+
+    sanitized[key] = sanitizeValue(key, value, expectedType)
+  }
+
+  return sanitized
+}
+
+function sanitizeValue(key, value, expectedType) {
+  if (expectedType === 'string') {
+    return sanitizeString(value, MAX_TEXT_LENGTH)
+  }
+
+  if (expectedType === 'url') {
+    const text = sanitizeString(value, 1000)
+    if (!text) return ''
+    if (isSafeUrl(text)) return text
+    throw new Error(`${key} must be an http, https, or relative URL`)
+  }
+
+  if (expectedType === 'number') {
+    const numberValue = Number(value)
+    if (!Number.isFinite(numberValue)) {
+      throw new Error(`${key} must be a number`)
+    }
+    return Math.max(0, Math.min(Math.round(numberValue), 24))
+  }
+
+  if (expectedType === 'boolean') {
+    if (value === true || value === 'true') return true
+    if (value === false || value === 'false') return false
+    throw new Error(`${key} must be true or false`)
+  }
+
+  if (expectedType.startsWith('enum:')) {
+    const options = expectedType.replace('enum:', '').split(',')
+    const text = sanitizeString(value, 100)
+    if (!options.includes(text)) {
+      throw new Error(`${key} must be one of: ${options.join(', ')}`)
+    }
+    return text
+  }
+
+  throw new Error(`Unsupported field type for ${key}`)
+}
+
+function sanitizeString(value, maxLength) {
+  if (value === undefined || value === null) return ''
+  if (typeof value !== 'string') {
+    throw new Error('Expected a string value')
+  }
+  return value.slice(0, maxLength)
+}
+
+function sanitizePlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return JSON.parse(JSON.stringify(value))
+}
+
+function isSafeUrl(value) {
+  if (value.startsWith('#')) return true
+  if (value.startsWith('/') && !value.startsWith('//')) return true
+
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function createDefaultHomeData(settings) {
+  return {
+    content: [
+      {
+        type: 'HeroSection',
+        props: {
+          id: 'home-hero',
+          title: settings.heroTitle || 'Welcome to OpenShop',
+          subtitle: settings.heroSubtitle || 'Discover amazing products at unbeatable prices. Built on Cloudflare for lightning-fast performance.',
+          imageUrl: settings.heroImageUrl || '',
+          primaryLabel: 'Shop Now',
+          primaryPath: '#products',
+          secondaryLabel: 'Learn More',
+          secondaryPath: '/about',
+        },
+      },
+      {
+        type: 'FeaturedProducts',
+        props: {
+          id: 'featured-products',
+          heading: 'Featured Products',
+          maxItems: 3,
+        },
+      },
+      {
+        type: 'ProductGrid',
+        props: {
+          id: 'product-grid',
+          heading: 'All Products',
+          showCollectionFilter: true,
+        },
+      },
+    ],
+    root: { props: {} },
+  }
+}
+
+function createDefaultAboutData(settings) {
+  return {
+    content: [
+      {
+        type: 'HeroSection',
+        props: {
+          id: 'about-hero',
+          title: settings.aboutHeroTitle || 'About Us',
+          subtitle: settings.aboutHeroSubtitle || 'Learn more about our story and mission',
+          imageUrl: settings.aboutHeroImageUrl || '',
+          primaryLabel: '',
+          primaryPath: '',
+          secondaryLabel: '',
+          secondaryPath: '',
+        },
+      },
+      {
+        type: 'RichTextSection',
+        props: {
+          id: 'about-content',
+          heading: '',
+          body: settings.aboutContent || 'Welcome to our store! We are passionate about providing high-quality products and exceptional customer service. Our journey began with a simple idea: to make great products accessible to everyone.\n\nWe believe in quality, sustainability, and building lasting relationships with our customers. Every product in our catalog is carefully selected to meet our high standards.\n\nThank you for choosing us for your shopping needs!',
+        },
+      },
+    ],
+    root: { props: {} },
+  }
+}

--- a/src/middleware/securityHeaders.js
+++ b/src/middleware/securityHeaders.js
@@ -23,7 +23,7 @@ export async function securityHeadersMiddleware(c, next) {
     "img-src 'self' data: https: blob:",
     "font-src 'self' data:",
     "connect-src 'self' https://api.stripe.com https://*.stripe.com https://oauth2.googleapis.com https://www.googleapis.com",
-    "frame-src https://js.stripe.com https://hooks.stripe.com",
+    "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
     "frame-ancestors 'none'",
     "base-uri 'self'",
     "form-action 'self'",

--- a/src/pages/storefront/About.jsx
+++ b/src/pages/storefront/About.jsx
@@ -1,85 +1,43 @@
 import { useEffect, useState } from 'react'
 import { Navbar } from '../../components/storefront/Navbar'
 import { Footer } from '../../components/storefront/Footer'
-import { normalizeImageUrl } from '../../lib/utils'
+import { PageRenderer } from '../../components/storefront/page-builder/PageRenderer'
 
 export function About() {
-  const [settings, setSettings] = useState({
-    aboutHeroImageUrl: '',
-    aboutHeroTitle: 'About Us',
-    aboutHeroSubtitle: 'Learn more about our story and mission',
-    aboutContent: 'Welcome to our store! We are passionate about providing high-quality products and exceptional customer service. Our journey began with a simple idea: to make great products accessible to everyone.\n\nWe believe in quality, sustainability, and building lasting relationships with our customers. Every product in our catalog is carefully selected to meet our high standards.\n\nThank you for choosing us for your shopping needs!'
-  })
+  const [page, setPage] = useState(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     let isMounted = true
-    async function fetchSettings() {
+
+    async function fetchPage() {
       try {
-        const res = await fetch('/api/store-settings')
+        const res = await fetch('/api/storefront/pages/about')
         if (res.ok) {
           const data = await res.json()
-          if (isMounted) setSettings(prev => ({
-            ...prev,
-            aboutHeroImageUrl: data.aboutHeroImageUrl || prev.aboutHeroImageUrl || '',
-            aboutHeroTitle: data.aboutHeroTitle || prev.aboutHeroTitle,
-            aboutHeroSubtitle: data.aboutHeroSubtitle || prev.aboutHeroSubtitle,
-            aboutContent: data.aboutContent || prev.aboutContent || ''
-          }))
+          if (isMounted) setPage(data)
         }
       } catch (e) {
-        console.error('Failed to load store settings', e)
+        console.error('Failed to load page content', e)
+      } finally {
+        if (isMounted) setLoading(false)
       }
     }
-    fetchSettings()
+
+    fetchPage()
     return () => { isMounted = false }
   }, [])
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen storefront-surface">
       <Navbar />
-
-      {/* Hero Section */}
-      <section className="relative w-screen overflow-hidden text-white">
-        {settings.aboutHeroImageUrl ? (
-          <img
-            src={normalizeImageUrl(settings.aboutHeroImageUrl)}
-            alt="About Hero"
-            className="w-screen h-auto max-h-[90vh] object-contain block mx-auto"
-          />
-        ) : (
-          <div className="w-screen min-h-[320px] sm:min-h-[420px] lg:min-h-[560px] bg-gradient-to-r from-slate-600 to-slate-700" />
-        )}
-
-        <div className="absolute inset-0 bg-black/40" aria-hidden />
-
-        <div className="absolute inset-0 flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 py-12 text-center">
-          <div className="max-w-4xl mx-auto space-y-6">
-            <h1 className="text-4xl md:text-6xl font-bold">{settings.aboutHeroTitle}</h1>
-            <p className="text-xl md:text-2xl max-w-3xl mx-auto">{settings.aboutHeroSubtitle}</p>
-          </div>
+      {loading ? (
+        <div className="flex h-96 items-center justify-center">
+          <p className="storefront-subtle">Loading page...</p>
         </div>
-
-        <div className="pointer-events-none absolute inset-0 overflow-hidden">
-          <div className="absolute top-10 left-10 w-20 h-20 bg-white opacity-10 rounded-full" />
-          <div className="absolute top-20 right-20 w-32 h-32 bg-white opacity-5 rounded-full" />
-          <div className="absolute bottom-10 left-1/4 w-16 h-16 bg-white opacity-10 rounded-full" />
-        </div>
-      </section>
-
-      {/* Content Section */}
-      <section className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div className="bg-white rounded-lg shadow-sm p-8 md:p-12">
-          <div className="prose prose-lg max-w-none">
-            {(settings.aboutContent || '').split('\n\n').map((paragraph, index) => (
-              <p key={index} className="mb-6 text-gray-700 leading-relaxed">
-                {paragraph}
-              </p>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Footer */}
+      ) : (
+        <PageRenderer data={page?.data} />
+      )}
       <Footer />
     </div>
   )

--- a/src/pages/storefront/Storefront.jsx
+++ b/src/pages/storefront/Storefront.jsx
@@ -1,15 +1,12 @@
 import { useState, useEffect } from 'react'
 import { Navbar } from '../../components/storefront/Navbar'
-import { Hero } from '../../components/storefront/Hero'
-import { Carousel } from '../../components/storefront/Carousel'
-import { ProductCard } from '../../components/storefront/ProductCard'
 import { Footer } from '../../components/storefront/Footer'
-import { Button } from '../../components/ui/button'
+import { PageRenderer } from '../../components/storefront/page-builder/PageRenderer'
 
 export function Storefront() {
   const [products, setProducts] = useState([])
   const [collections, setCollections] = useState([])
-  const [selectedCollection, setSelectedCollection] = useState(null)
+  const [page, setPage] = useState(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -21,9 +18,10 @@ export function Storefront() {
       setLoading(true)
       
       // Fetch products and collections
-      const [productsResponse, collectionsResponse] = await Promise.all([
+      const [productsResponse, collectionsResponse, pageResponse] = await Promise.all([
         fetch('/api/products'),
-        fetch('/api/collections')
+        fetch('/api/collections'),
+        fetch('/api/storefront/pages/home')
       ])
 
       if (productsResponse.ok) {
@@ -35,18 +33,17 @@ export function Storefront() {
         const collectionsData = await collectionsResponse.json()
         setCollections(collectionsData)
       }
+
+      if (pageResponse.ok) {
+        const pageData = await pageResponse.json()
+        setPage(pageData)
+      }
     } catch (error) {
       console.error('Error fetching data:', error)
     } finally {
       setLoading(false)
     }
   }
-
-  const filteredProducts = selectedCollection
-    ? products.filter(product => product.collectionId === selectedCollection)
-    : products
-
-  const featuredProducts = products.slice(0, 3) // Show first 3 products in carousel
 
   if (loading) {
     return (
@@ -71,73 +68,7 @@ export function Storefront() {
   return (
     <div className="min-h-screen storefront-surface">
       <Navbar />
-      
-      {/* Hero Section */}
-      <Hero />
-
-      {/* Featured Products Carousel */}
-      {featuredProducts.length > 0 && (
-        <section className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-          <h2 className="text-3xl font-bold storefront-heading mb-8 text-center">
-            Featured Products
-          </h2>
-          <Carousel products={featuredProducts} />
-        </section>
-      )}
-
-      {/* Collection Filter */}
-      <section className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="flex flex-wrap gap-4 justify-center">
-          <Button
-            variant={selectedCollection === null ? 'default' : 'outline'}
-            onClick={() => setSelectedCollection(null)}
-          >
-            All Products
-          </Button>
-          {collections.map((collection) => (
-            <Button
-              key={collection.id}
-              variant={selectedCollection === collection.id ? 'default' : 'outline'}
-              onClick={() => setSelectedCollection(collection.id)}
-            >
-              {collection.name}
-            </Button>
-          ))}
-        </div>
-      </section>
-
-      {/* Products Grid */}
-      <section className="max-w-8xl mx-auto px-3 sm:px-4 lg:px-6 pb-16">
-        {filteredProducts.length === 0 ? (
-          <div className="text-center py-16">
-            <div className="storefront-subtle mb-4">
-              <svg className="w-16 h-16 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
-              </svg>
-            </div>
-            <h3 className="text-xl font-semibold storefront-heading mb-2">No products found</h3>
-            <p className="storefront-subtle mb-6">
-              {selectedCollection 
-                ? 'No products in this collection yet.' 
-                : 'No products available at the moment.'
-              }
-            </p>
-            {selectedCollection && (
-              <Button onClick={() => setSelectedCollection(null)}>
-                View All Products
-              </Button>
-            )}
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6">
-            {filteredProducts.map((product) => (
-              <ProductCard key={product.id} product={product} />
-            ))}
-          </div>
-        )}
-      </section>
-
-      {/* Footer */}
+      <PageRenderer data={page?.data} products={products} collections={collections} />
       <Footer />
     </div>
   )

--- a/src/routes/admin/settings.js
+++ b/src/routes/admin/settings.js
@@ -2,6 +2,7 @@
 import { Hono } from 'hono'
 import { ThemeService } from '../../services/ThemeService.js'
 import { StoreSettingsService } from '../../services/StoreSettingsService.js'
+import { PageContentService } from '../../services/PageContentService.js'
 import { getKVNamespace } from '../../utils/kv.js'
 import { validateThemePayload } from '../../middleware/validation.js'
 import { asyncHandler } from '../../middleware/errorHandler.js'
@@ -58,6 +59,35 @@ router.put('/store-settings', asyncHandler(async (c) => {
   const settingsService = new StoreSettingsService(kvNamespace)
   const updatedSettings = await settingsService.updateSettings(settings)
   return c.json(updatedSettings)
+}))
+
+// Get page-builder content
+router.get('/storefront/pages/:slug', asyncHandler(async (c) => {
+  const slug = c.req.param('slug')
+  const kvNamespace = getKVNamespace(c.env)
+  const pageContentService = new PageContentService(kvNamespace)
+
+  try {
+    const page = await pageContentService.getPage(slug)
+    return c.json(page)
+  } catch (error) {
+    throw new ValidationError(error.message)
+  }
+}))
+
+// Publish page-builder content
+router.put('/storefront/pages/:slug', asyncHandler(async (c) => {
+  const slug = c.req.param('slug')
+  const payload = await c.req.json()
+  const kvNamespace = getKVNamespace(c.env)
+  const pageContentService = new PageContentService(kvNamespace)
+
+  try {
+    const page = await pageContentService.updatePage(slug, payload.data || payload)
+    return c.json(page)
+  } catch (error) {
+    throw new ValidationError(error.message)
+  }
 }))
 
 export default router

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ import checkoutRouter from './public/checkout.js'
 import imageProxyRouter from './public/imageProxy.js'
 import storeSettingsRouter, { contactEmailRouter } from './public/storeSettings.js'
 import imagesRouter from './public/images.js'
+import pagesRouter from './public/pages.js'
 
 // Admin routes
 import authRouter from './admin/auth.js'
@@ -39,6 +40,7 @@ export function registerRoutes(app) {
   app.route('/api/store-settings', storeSettingsRouter)
   app.route('/api/contact-email', contactEmailRouter)
   app.route('/api/images', imagesRouter)
+  app.route('/api/storefront/pages', pagesRouter)
 
   // Admin API routes
   app.route('/api/admin', authRouter) // /api/admin/login

--- a/src/routes/public/pages.js
+++ b/src/routes/public/pages.js
@@ -1,0 +1,22 @@
+import { Hono } from 'hono'
+import { PageContentService } from '../../services/PageContentService.js'
+import { getKVNamespace } from '../../utils/kv.js'
+import { asyncHandler } from '../../middleware/errorHandler.js'
+import { ValidationError } from '../../utils/errors.js'
+
+const router = new Hono()
+
+router.get('/:slug', asyncHandler(async (c) => {
+  const slug = c.req.param('slug')
+  const kvNamespace = getKVNamespace(c.env)
+  const service = new PageContentService(kvNamespace)
+
+  try {
+    const page = await service.getPage(slug)
+    return c.json(page)
+  } catch (error) {
+    throw new ValidationError(error.message)
+  }
+}))
+
+export default router

--- a/src/services/PageContentService.js
+++ b/src/services/PageContentService.js
@@ -1,0 +1,33 @@
+import {
+  createDefaultPageRecord,
+  createPageRecord,
+  getPageContentKey,
+  validatePageRecord,
+} from '../lib/pageContent.js'
+import { StoreSettingsService } from './StoreSettingsService.js'
+
+export class PageContentService {
+  constructor(kvNamespace) {
+    this.kv = kvNamespace
+    this.settingsService = new StoreSettingsService(kvNamespace)
+  }
+
+  async getPage(slug) {
+    const key = getPageContentKey(slug)
+    const raw = await this.kv.get(key)
+
+    if (raw) {
+      return validatePageRecord(JSON.parse(raw))
+    }
+
+    const settings = await this.settingsService.getSettings()
+    return createDefaultPageRecord(slug, settings)
+  }
+
+  async updatePage(slug, data) {
+    const key = getPageContentKey(slug)
+    const record = createPageRecord(slug, data)
+    await this.kv.put(key, JSON.stringify(record))
+    return record
+  }
+}

--- a/tests/integration/admin-settings.test.js
+++ b/tests/integration/admin-settings.test.js
@@ -1,6 +1,6 @@
 // Integration tests for admin settings endpoints
 import { describe, it, expect, beforeEach } from 'vitest'
-import { createTestApp, createTestRequest, executeRequest, parseJsonResponse, createAdminToken, createAdminHeaders, createTestStoreSettings } from '../utils/test-helpers.js'
+import { createTestApp, createTestRequest, executeRequest, parseJsonResponse, createAdminToken, createAdminHeaders } from '../utils/test-helpers.js'
 import { createMockEnv, createMockKV } from '../setup.js'
 import { KV_KEYS } from '../../src/config/index.js'
 
@@ -92,8 +92,6 @@ describe('Admin Settings Endpoints', () => {
       })
 
       const response = await executeRequest(app, request, env)
-      const data = await parseJsonResponse(response)
-
       // May return 400 or 200 depending on validation implementation
       expect([200, 400]).toContain(response.status)
     })
@@ -177,8 +175,6 @@ describe('Admin Settings Endpoints', () => {
       })
 
       const response = await executeRequest(app, request, env)
-      const data = await parseJsonResponse(response)
-
       expect(response.status).toBe(500) // Service throws error for invalid logoType
     })
 
@@ -245,6 +241,95 @@ describe('Admin Settings Endpoints', () => {
 
       const response = await executeRequest(app, request, env)
       expect(response.status).toBe(401)
+    })
+  })
+
+  describe('GET /api/admin/storefront/pages/:slug', () => {
+    it('should return default page content', async () => {
+      const request = createTestRequest('/api/admin/storefront/pages/home', {
+        method: 'GET',
+        headers: createAdminHeaders(adminToken)
+      })
+
+      const response = await executeRequest(app, request, env)
+      const data = await parseJsonResponse(response)
+
+      expect(response.status).toBe(200)
+      expect(data.slug).toBe('home')
+      expect(Array.isArray(data.data.content)).toBe(true)
+    })
+
+    it('should require authentication', async () => {
+      const request = createTestRequest('/api/admin/storefront/pages/home')
+
+      const response = await executeRequest(app, request, env)
+
+      expect(response.status).toBe(401)
+    })
+
+    it('should reject invalid slugs', async () => {
+      const request = createTestRequest('/api/admin/storefront/pages/checkout', {
+        method: 'GET',
+        headers: createAdminHeaders(adminToken)
+      })
+
+      const response = await executeRequest(app, request, env)
+
+      expect(response.status).toBe(400)
+    })
+  })
+
+  describe('PUT /api/admin/storefront/pages/:slug', () => {
+    it('should publish valid page content', async () => {
+      const request = createTestRequest('/api/admin/storefront/pages/about', {
+        method: 'PUT',
+        body: {
+          data: {
+            content: [
+              {
+                type: 'RichTextSection',
+                props: {
+                  id: 'about-content',
+                  heading: 'About',
+                  body: 'Updated content'
+                }
+              }
+            ],
+            root: { props: {} }
+          }
+        },
+        headers: createAdminHeaders(adminToken)
+      })
+
+      const response = await executeRequest(app, request, env)
+      const data = await parseJsonResponse(response)
+
+      expect(response.status).toBe(200)
+      expect(data.slug).toBe('about')
+      expect(data.updatedAt).toBeTruthy()
+      expect(data.data.content[0].props.body).toBe('Updated content')
+    })
+
+    it('should reject unsupported components', async () => {
+      const request = createTestRequest('/api/admin/storefront/pages/home', {
+        method: 'PUT',
+        body: {
+          data: {
+            content: [
+              {
+                type: 'ScriptBlock',
+                props: { id: 'x' }
+              }
+            ],
+            root: { props: {} }
+          }
+        },
+        headers: createAdminHeaders(adminToken)
+      })
+
+      const response = await executeRequest(app, request, env)
+
+      expect(response.status).toBe(400)
     })
   })
 })

--- a/tests/integration/public-endpoints.test.js
+++ b/tests/integration/public-endpoints.test.js
@@ -1,6 +1,6 @@
 // Integration tests for public API endpoints
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { createTestApp, createTestRequest, executeRequest, parseJsonResponse, setupTestEnvironment, createTestProduct, createTestCollection, createTestStoreSettings, setupProductInKV, setupCollectionInKV } from '../utils/test-helpers.js'
+import { createTestApp, createTestRequest, executeRequest, parseJsonResponse, createTestProduct, createTestCollection, createTestStoreSettings, setupProductInKV, setupCollectionInKV } from '../utils/test-helpers.js'
 import { createMockEnv, createMockKV } from '../setup.js'
 
 describe('Public Endpoints', () => {
@@ -218,6 +218,27 @@ describe('Public Endpoints', () => {
 
       expect(response.status).toBe(200)
       expect(data.storeName).toBe('Custom Store')
+    })
+  })
+
+  describe('GET /api/storefront/pages/:slug', () => {
+    it('should return default public home page content', async () => {
+      const request = createTestRequest('/api/storefront/pages/home')
+
+      const response = await executeRequest(app, request, env)
+      const data = await parseJsonResponse(response)
+
+      expect(response.status).toBe(200)
+      expect(data.slug).toBe('home')
+      expect(Array.isArray(data.data.content)).toBe(true)
+    })
+
+    it('should reject invalid public page slugs', async () => {
+      const request = createTestRequest('/api/storefront/pages/checkout')
+
+      const response = await executeRequest(app, request, env)
+
+      expect(response.status).toBe(400)
     })
   })
 

--- a/tests/unit/services/PageContentService.test.js
+++ b/tests/unit/services/PageContentService.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { PageContentService } from '../../../src/services/PageContentService.js'
+import { createMockKV } from '../../setup.js'
+import { getPageContentKey } from '../../../src/lib/pageContent.js'
+import { KV_KEYS } from '../../../src/config/index.js'
+
+describe('PageContentService', () => {
+  let service
+  let kv
+
+  beforeEach(() => {
+    kv = createMockKV()
+    service = new PageContentService(kv)
+  })
+
+  it('returns default home data derived from store settings', async () => {
+    await kv.put(KV_KEYS.STORE_SETTINGS, JSON.stringify({
+      logoType: 'text',
+      heroTitle: 'Custom home',
+      heroSubtitle: 'Custom subtitle',
+      heroImageUrl: 'https://example.com/hero.jpg',
+    }))
+
+    const page = await service.getPage('home')
+
+    expect(page.slug).toBe('home')
+    expect(page.updatedAt).toBeNull()
+    expect(page.data.content[0].type).toBe('HeroSection')
+    expect(page.data.content[0].props.title).toBe('Custom home')
+    expect(page.data.content[0].props.imageUrl).toBe('https://example.com/hero.jpg')
+  })
+
+  it('returns stored page data', async () => {
+    const stored = {
+      slug: 'about',
+      version: 1,
+      updatedAt: '2026-05-28T00:00:00.000Z',
+      data: {
+        content: [
+          {
+            type: 'RichTextSection',
+            props: {
+              id: 'custom',
+              heading: 'Story',
+              body: 'Body',
+            },
+          },
+        ],
+        root: { props: {} },
+      },
+    }
+    await kv.put(getPageContentKey('about'), JSON.stringify(stored))
+
+    const page = await service.getPage('about')
+
+    expect(page).toEqual(stored)
+  })
+
+  it('rejects invalid slugs', async () => {
+    await expect(service.getPage('checkout')).rejects.toThrow('Invalid page slug')
+  })
+
+  it('rejects invalid page data shape', async () => {
+    await expect(service.updatePage('home', { content: 'invalid', root: {} })).rejects.toThrow('content array')
+  })
+
+  it('rejects unsupported components', async () => {
+    await expect(service.updatePage('home', {
+      content: [
+        {
+          type: 'ScriptBlock',
+          props: { id: 'script', body: '<script>alert(1)</script>' },
+        },
+      ],
+      root: { props: {} },
+    })).rejects.toThrow('Unsupported page component')
+  })
+
+  it('stores valid page data', async () => {
+    const page = await service.updatePage('home', {
+      content: [
+        {
+          type: 'HeroSection',
+          props: {
+            id: 'hero',
+            title: 'New title',
+            subtitle: 'New subtitle',
+            imageUrl: '/hero.jpg',
+            primaryLabel: 'Shop',
+            primaryPath: '#products',
+            secondaryLabel: 'About',
+            secondaryPath: '/about',
+          },
+        },
+      ],
+      root: { props: {} },
+    })
+
+    expect(page.updatedAt).toBeTruthy()
+    expect(page.data.content[0].props.title).toBe('New title')
+    expect(await kv.get(getPageContentKey('home'))).toBeTruthy()
+  })
+})

--- a/tests/utils/test-helpers.js
+++ b/tests/utils/test-helpers.js
@@ -75,7 +75,7 @@ export async function createTestApp() {
       "img-src 'self' data: https: blob:",
       "font-src 'self' data:",
       "connect-src 'self' https://api.stripe.com https://*.stripe.com https://oauth2.googleapis.com https://www.googleapis.com",
-      "frame-src https://js.stripe.com https://hooks.stripe.com",
+      "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",
@@ -143,11 +143,9 @@ export function createTestRequest(url, options = {}) {
     method = 'GET',
     body = null,
     headers = {},
-    params = {}
   } = options
 
   const fullUrl = url.startsWith('http') ? url : `https://test.workers.dev${url}`
-  const urlObj = new URL(fullUrl)
 
   // Create headers object
   const headersObj = new Headers(headers)


### PR DESCRIPTION
## Summary
- add Puck-backed page content storage and validation for Home/About pages
- replace the old page-content settings panels with a lazy-loaded Puck Pages tab
- render Puck JSON on the public Home/About storefront pages while keeping products, collections, nav, footer, cart, and checkout code-owned
- document the new APIs/KV model and cover service/public/admin route behavior with tests

## Local validation
- `npm run harness:validate` passed
- `npm test -- --run` passed
- `npm run build` passed
- `npm run lint` currently fails on pre-existing unrelated unused-variable/hook warnings outside this change; changed-file ESLint passed before commit