### PR TITLE
Fix admin API paths and Puck CSP stylesheet import

### DIFF
--- a/src/components/admin/ProductWorkspace.jsx
+++ b/src/components/admin/ProductWorkspace.jsx
@@ -370,7 +370,7 @@ export function ProductWorkspace() {
 
   const fetchStoreSettings = async () => {
     try {
-      const settingsRes = await adminApiRequest('/api/admin/settings/store-settings')
+      const settingsRes = await adminApiRequest('/api/admin/store-settings')
       if (settingsRes.ok) {
         const settingsData = await settingsRes.json()
         setStoreSettings(settingsData)

--- a/src/components/admin/PuckPageEditor.jsx
+++ b/src/components/admin/PuckPageEditor.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Puck } from '@puckeditor/core'
-import '@puckeditor/core/puck.css'
+import '@puckeditor/core/no-external.css'
 import { adminApiRequest } from '../../lib/auth'
 import { createPageBuilderConfig } from '../storefront/page-builder/config'
 

--- a/src/pages/admin/FulfillmentPage.jsx
+++ b/src/pages/admin/FulfillmentPage.jsx
@@ -37,7 +37,7 @@ export function FulfillmentPage() {
       })
       if (cursor) params.set('cursor', cursor)
       if (dir) params.set('direction', dir)
-      const res = await adminApiRequest(`/api/admin/orders?${params.toString()}`)
+      const res = await adminApiRequest(`/api/admin/analytics/orders?${params.toString()}`)
       if (!res.ok) throw new Error('Failed to fetch orders')
       const data = await res.json()
       setOrders(data.orders || [])
@@ -53,7 +53,7 @@ export function FulfillmentPage() {
 
   const fulfillOrder = async (orderId) => {
     try {
-      const res = await adminApiRequest(`/api/admin/orders/${orderId}/fulfill`, {
+      const res = await adminApiRequest(`/api/admin/analytics/orders/${orderId}/fulfill`, {
         method: 'POST',
       })
       if (!res.ok) throw new Error('Failed to fulfill order')


### PR DESCRIPTION
## Summary
- Fix ProductWorkspace store-settings fetch to use /api/admin/store-settings
- Fix FulfillmentPage order list and fulfill endpoints to use /api/admin/analytics/orders
- Switch PuckPageEditor to @puckeditor/core/no-external.css for CSP compatibility

## Test plan
- [x] npm run harness:validate
- [x] npm test -- --run
- [x] npm run build
- [ ] Verify fulfillment page loads orders in admin
- [ ] Verify product workspace loads store settings
- [ ] Verify Puck page editor renders without CSP violations

Made with [Cursor](https://cursor.com)