### PR TITLE
Disable rounded corners in default store theme

### DIFF
--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -50,7 +50,7 @@ const DEFAULT_STORE_THEME = {
     fontId: 'inter',
   },
   corners: {
-    enabled: true,
+    enabled: false,
     radiusMultiplier: 1,
   },
 }


### PR DESCRIPTION
## Summary
- Set `corners.enabled` to `false` in `DEFAULT_STORE_THEME` so new stores start with square corners unless merchants enable rounding in theme settings.

## Test plan
- [x] `npm run lint`
- [x] `npm run harness:validate`
- [x] `npm test -- --run`
- [x] `npm run build`