### PR TITLE
⚡ Parallelize reference image fetching in AddMediaModal

### DIFF
--- a/benchmarks/add-media-benchmark.js
+++ b/benchmarks/add-media-benchmark.js
@@ -1,0 +1,77 @@
+
+import { performance } from 'perf_hooks';
+
+// Simulate the logic in AddMediaModal.jsx
+async function blobToBase64(blob) {
+  // Simulate FileReader and processing time
+  await new Promise(resolve => setTimeout(resolve, 10));
+  return { mimeType: 'image/png', base64: 'base64data' };
+}
+
+async function fetchSimulated(url) {
+  // Simulate network delay
+  await new Promise(resolve => setTimeout(resolve, 100));
+  return {
+    ok: true,
+    blob: async () => ({ type: 'image/png' })
+  };
+}
+
+async function sequential(refUrls) {
+  const start = performance.now();
+  const inputs = [];
+  for (const url of refUrls.slice(0, 3)) {
+    try {
+      const proxied = `/api/image-proxy?src=${encodeURIComponent(url)}`;
+      const resp = await fetchSimulated(proxied);
+      if (!resp.ok) continue;
+      const blob = await resp.blob();
+      const { mimeType, base64 } = await blobToBase64(blob);
+      if (base64) inputs.push({ mimeType, dataBase64: base64 });
+    } catch (_) {}
+  }
+  const end = performance.now();
+  return { duration: end - start, count: inputs.length };
+}
+
+async function parallel(refUrls) {
+  const start = performance.now();
+
+  const promises = refUrls.slice(0, 3).map(async (url) => {
+    try {
+      const proxied = `/api/image-proxy?src=${encodeURIComponent(url)}`;
+      const resp = await fetchSimulated(proxied);
+      if (!resp.ok) return null;
+      const blob = await resp.blob();
+      const { mimeType, base64 } = await blobToBase64(blob);
+      if (base64) return { mimeType, dataBase64: base64 };
+    } catch (_) {
+      return null;
+    }
+    return null;
+  });
+
+  const results = await Promise.all(promises);
+  const inputs = results.filter(Boolean);
+
+  const end = performance.now();
+  return { duration: end - start, count: inputs.length };
+}
+
+async function run() {
+  const urls = ['url1', 'url2', 'url3'];
+
+  console.log('Establishing baseline (Sequential)...');
+  const seqResult = await sequential(urls);
+  console.log(`Sequential: ${seqResult.duration.toFixed(2)}ms for ${seqResult.count} images`);
+
+  console.log('\nMeasuring optimization (Parallel)...');
+  const parResult = await parallel(urls);
+  console.log(`Parallel: ${parResult.duration.toFixed(2)}ms for ${parResult.count} images`);
+
+  const improvement = seqResult.duration - parResult.duration;
+  const percent = (improvement / seqResult.duration) * 100;
+  console.log(`\nImprovement: ${improvement.toFixed(2)}ms (${percent.toFixed(2)}%)`);
+}
+
+run().catch(console.error);

--- a/src/components/admin/AddMediaModal.jsx
+++ b/src/components/admin/AddMediaModal.jsx
@@ -154,18 +154,21 @@ export default function AddMediaModal({ open, onClose, onCreated }) {
     setResultBase64('')
     setError('')
     try {
-      // Build inputs from selected reference images (up to 3)
-      const inputs = []
-      for (const url of refUrls.slice(0, 3)) {
+      // Build inputs from selected reference images (up to 3) in parallel
+      const inputPromises = refUrls.slice(0, 3).map(async (url) => {
         try {
           const proxied = `/api/image-proxy?src=${encodeURIComponent(url)}`
           const resp = await fetch(proxied)
-          if (!resp.ok) continue
+          if (!resp.ok) return null
           const blob = await resp.blob()
           const { mimeType, base64 } = await blobToBase64(blob)
-          if (base64) inputs.push({ mimeType, dataBase64: base64 })
-        } catch (_) {}
-      }
+          return base64 ? { mimeType, dataBase64: base64 } : null
+        } catch (_) {
+          return null
+        }
+      })
+      const results = await Promise.all(inputPromises)
+      const inputs = results.filter(Boolean)
 
       const res = await adminApiRequest('/api/admin/ai/generate-image', {
         method: 'POST',


### PR DESCRIPTION
I have optimized the `AddMediaModal` component by parallelizing the fetching and processing of reference images used for AI generation. 

Previously, if a user selected 3 reference images, they were fetched and converted to base64 sequentially, which took approximately 3x longer than necessary. By using `Promise.all`, these operations now happen concurrently.

Key improvements:
- **Performance:** Reduced time spent fetching reference images by ~66% in benchmarks (from ~330ms to ~110ms for 3 images).
- **Resilience:** Maintained robust error handling where individual image fetch failures do not block the entire generation process.
- **Verification:** Included a new benchmark script `benchmarks/add-media-benchmark.js` to validate the performance gains.

---
*PR created automatically by Jules for task [17764055140140045476](https://jules.google.com/task/17764055140140045476) started by @AJFrio*