### PR TITLE
fix: admin login uses ADMIN_PASSWORD secret only

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -112,13 +112,13 @@ Always test thoroughly with test keys before switching to live mode.
 
 ## Admin Password
 
-Set a secure admin password during setup. This password is used to access the admin dashboard at `/admin`.
+Set a secure admin password during setup (`ADMIN_PASSWORD`). Login compares the submitted password to this Worker secret/env var — it is not stored in KV.
 
 **Security Tips:**
 - Use a strong, unique password
 - Don't share your admin password
-- Change it regularly if compromised
-- The password is stored securely in Cloudflare Workers secrets
+- Rotate it by updating the `ADMIN_PASSWORD` Worker secret (or via OpenShop Service reset)
+- Never put `ADMIN_PASSWORD` in client-side code or public repos
 
 ## Site URL
 

--- a/src/components/admin/AdminLogin.jsx
+++ b/src/components/admin/AdminLogin.jsx
@@ -15,11 +15,11 @@ export function AdminLogin({ onLoginSuccess }) {
     setError('')
 
     try {
-      const success = await adminLogin(password)
-      if (success) {
+      const result = await adminLogin(password)
+      if (result.ok) {
         onLoginSuccess()
       } else {
-        setError('Invalid password. Please try again.')
+        setError(result.error || 'Invalid password. Please try again.')
       }
     } catch {
       setError('Login failed. Please try again.')

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -81,7 +81,11 @@ export async function adminApiRequest(url, options = {}) {
   return response
 }
 
-// Simple admin login (in production, implement proper password authentication)
+/**
+ * Admin login against Worker ADMIN_PASSWORD.
+ * @param {string} password
+ * @returns {Promise<{ ok: true } | { ok: false, error: string }>}
+ */
 export async function adminLogin(password) {
   try {
     const response = await fetch('/api/admin/login', {
@@ -95,12 +99,16 @@ export async function adminLogin(password) {
     if (response.ok) {
       const { token } = await response.json()
       setAdminToken(token)
-      return true
-    } else {
-      return false
+      return { ok: true }
+    }
+
+    const errorData = await response.json().catch(() => ({}))
+    return {
+      ok: false,
+      error: errorData.error || 'Invalid password. Please try again.',
     }
   } catch (error) {
     console.error('Admin login error:', error)
-    return false
+    return { ok: false, error: 'Login failed. Please try again.' }
   }
 }

--- a/src/routes/admin/auth.js
+++ b/src/routes/admin/auth.js
@@ -1,7 +1,6 @@
 // Admin authentication routes
 import { Hono } from 'hono'
-import { generateSessionToken } from '../../utils/crypto.js'
-import { hashToken, verifyPassword, hashPasswordWithSalt } from '../../utils/crypto.js'
+import { generateSessionToken, hashToken, timingSafeEqualStrings } from '../../utils/crypto.js'
 import { getKVNamespace } from '../../utils/kv.js'
 import { ADMIN_TOKEN_TTL, KV_KEYS } from '../../config/index.js'
 import { asyncHandler } from '../../middleware/errorHandler.js'
@@ -29,20 +28,9 @@ router.post('/login', asyncHandler(async (c) => {
     throw new AuthenticationError('Too many login attempts. Please try again later.')
   }
 
-  // Get stored password hash or use default (will be hashed on first use)
-  const storedHashKey = `${KV_KEYS.ADMIN_TOKEN_PREFIX}password_hash`
-  let storedHash = await kvNamespace.get(storedHashKey)
-  
+  // ADMIN_PASSWORD Worker secret/env is the single source of truth (not KV)
   const adminPassword = c.env.ADMIN_PASSWORD || 'admin123'
-  
-  // If no hash stored, create one from the current password
-  if (!storedHash) {
-    storedHash = await hashPasswordWithSalt(adminPassword)
-    await kvNamespace.put(storedHashKey, storedHash)
-  }
-  
-  // Verify password
-  const isValid = await verifyPassword(password, storedHash)
+  const isValid = await timingSafeEqualStrings(password, adminPassword)
   
   if (!isValid) {
     // Increment rate limit counter
@@ -55,6 +43,9 @@ router.post('/login', asyncHandler(async (c) => {
   // Clear rate limit on successful login
   await kvNamespace.delete(rateLimitKey)
 
+  // Clean up legacy KV password hash from older deploys
+  await kvNamespace.delete(`${KV_KEYS.ADMIN_TOKEN_PREFIX}password_hash`)
+
   const token = generateSessionToken()
   const hashedToken = await hashToken(token)
 
@@ -66,4 +57,3 @@ router.post('/login', asyncHandler(async (c) => {
 }))
 
 export default router
-

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -63,92 +63,38 @@ export async function hashToken(token) {
 }
 
 /**
- * Hashes a password using PBKDF2 (for password verification)
- * Note: In production, consider using a more secure method like Argon2
- * @param {string} password - Password to hash
- * @param {string} salt - Salt (hex string)
- * @param {number} iterations - Number of iterations (default: 100000)
- * @returns {Promise<string>} - Hashed password (hex string)
+ * Timing-safe string comparison via SHA-256 digests.
+ * Avoids leaking password length/content through early exits on raw bytes.
+ * @param {string} a
+ * @param {string} b
+ * @returns {Promise<boolean>}
  */
-export async function hashPassword(password, salt, iterations = 100000) {
+export async function timingSafeEqualStrings(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') {
+    return false
+  }
+
   const cryptoObj = getCrypto()
-  if (!cryptoObj.subtle) {
-    throw new Error('Web Crypto API is not available for password hashing')
+  if (!cryptoObj.subtle || typeof cryptoObj.subtle.digest !== 'function') {
+    throw new Error('Web Crypto API is not available for secure comparison')
   }
 
   const encoder = new TextEncoder()
-  const passwordData = encoder.encode(password)
-  
-  // Convert salt from hex to Uint8Array
-  const saltBytes = new Uint8Array(salt.match(/.{1,2}/g).map(byte => parseInt(byte, 16)))
-  
-  // Import password as key
-  const keyMaterial = await cryptoObj.subtle.importKey(
-    'raw',
-    passwordData,
-    { name: 'PBKDF2' },
-    false,
-    ['deriveBits']
-  )
-  
-  // Derive key using PBKDF2
-  const derivedBits = await cryptoObj.subtle.deriveBits(
-    {
-      name: 'PBKDF2',
-      salt: saltBytes,
-      iterations: iterations,
-      hash: 'SHA-256'
-    },
-    keyMaterial,
-    256 // 256 bits = 32 bytes
-  )
-  
-  // Convert to hex string
-  return Array.from(new Uint8Array(derivedBits))
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('')
-}
+  const [digestA, digestB] = await Promise.all([
+    cryptoObj.subtle.digest('SHA-256', encoder.encode(a)),
+    cryptoObj.subtle.digest('SHA-256', encoder.encode(b)),
+  ])
 
-/**
- * Verifies a password against a hash
- * @param {string} password - Password to verify
- * @param {string} hash - Stored hash (format: iterations:salt:hash)
- * @returns {Promise<boolean>} - True if password matches
- */
-export async function verifyPassword(password, hash) {
-  try {
-    const [iterationsStr, salt, expectedHash] = hash.split(':')
-    const iterations = parseInt(iterationsStr, 10)
-    
-    if (!iterations || !salt || !expectedHash) {
-      return false
-    }
-    
-    const computedHash = await hashPassword(password, salt, iterations)
-    return computedHash === expectedHash
-  } catch (error) {
+  const bytesA = new Uint8Array(digestA)
+  const bytesB = new Uint8Array(digestB)
+  if (bytesA.length !== bytesB.length) {
     return false
   }
-}
 
-/**
- * Generates a random salt for password hashing
- * @param {number} bytes - Number of bytes (default: 16)
- * @returns {string} - Salt as hex string
- */
-export function generateSalt(bytes = 16) {
-  return randomHex(bytes)
-}
-
-/**
- * Hashes a password with a new salt
- * @param {string} password - Password to hash
- * @param {number} iterations - Number of iterations (default: 100000)
- * @returns {Promise<string>} - Hash in format: iterations:salt:hash
- */
-export async function hashPasswordWithSalt(password, iterations = 100000) {
-  const salt = generateSalt(16)
-  const hash = await hashPassword(password, salt, iterations)
-  return `${iterations}:${salt}:${hash}`
+  let diff = 0
+  for (let i = 0; i < bytesA.length; i++) {
+    diff |= bytesA[i] ^ bytesB[i]
+  }
+  return diff === 0
 }
 

--- a/tests/integration/admin-auth.test.js
+++ b/tests/integration/admin-auth.test.js
@@ -1,8 +1,7 @@
 // Integration tests for admin authentication
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { createTestApp, createTestRequest, executeRequest, parseJsonResponse, createAdminToken, createAdminHeaders } from '../utils/test-helpers.js'
 import { createMockEnv, createMockKV } from '../setup.js'
-import { hashPasswordWithSalt, verifyPassword } from '../../src/utils/crypto.js'
 import { KV_KEYS } from '../../src/config/index.js'
 
 describe('Admin Authentication', () => {
@@ -72,10 +71,9 @@ describe('Admin Authentication', () => {
       expect(data.error).toContain('Invalid password')
     })
 
-    it('should hash password on first use', async () => {
-      // Clear any existing password hash
+    it('should authenticate against ADMIN_PASSWORD without storing a KV password hash', async () => {
       const hashKey = `${KV_KEYS.ADMIN_TOKEN_PREFIX}password_hash`
-      await kv.delete(hashKey)
+      await kv.put(hashKey, 'stale:hash:value')
 
       const request = createTestRequest('/api/admin/login', {
         method: 'POST',
@@ -88,10 +86,9 @@ describe('Admin Authentication', () => {
       expect(response.status).toBe(200)
       expect(data.token).toBeDefined()
 
-      // Verify password hash was stored
+      // Legacy hash cleaned up; password is not stored in KV
       const storedHash = await kv.get(hashKey)
-      expect(storedHash).toBeTruthy()
-      expect(storedHash).toContain(':') // Format: iterations:salt:hash
+      expect(storedHash).toBeNull()
     })
 
     it('should store token in KV after successful login', async () => {
@@ -105,15 +102,10 @@ describe('Admin Authentication', () => {
 
       expect(response.status).toBe(200)
       expect(data.token).toBeDefined()
-
-      // Token should be stored in KV (we can't easily verify the hashed key, but we can check the response)
       expect(data.token).toBeTruthy()
     })
 
     it('should implement rate limiting', async () => {
-      const rateLimitKey = 'rate_limit:login:test-ip'
-      
-      // Simulate 5 failed attempts
       for (let i = 0; i < 5; i++) {
         const request = createTestRequest('/api/admin/login', {
           method: 'POST',
@@ -123,7 +115,6 @@ describe('Admin Authentication', () => {
         await executeRequest(app, request, env)
       }
 
-      // 6th attempt should be rate limited
       const request = createTestRequest('/api/admin/login', {
         method: 'POST',
         body: { password: 'wrong_password' },
@@ -139,11 +130,8 @@ describe('Admin Authentication', () => {
 
     it('should clear rate limit on successful login', async () => {
       const rateLimitKey = 'rate_limit:login:test-ip'
-      
-      // Set up rate limit
       await kv.put(rateLimitKey, '4', { expirationTtl: 900 })
 
-      // Successful login should clear the rate limit
       const request = createTestRequest('/api/admin/login', {
         method: 'POST',
         body: { password: env.ADMIN_PASSWORD },
@@ -151,11 +139,8 @@ describe('Admin Authentication', () => {
       })
 
       const response = await executeRequest(app, request, env)
-      const data = await parseJsonResponse(response)
-
       expect(response.status).toBe(200)
-      
-      // Rate limit should be cleared
+
       const rateLimitValue = await kv.get(rateLimitKey)
       expect(rateLimitValue).toBeNull()
     })
@@ -172,8 +157,6 @@ describe('Admin Authentication', () => {
       })
 
       const response = await executeRequest(app, request, env)
-
-      // Should not return 401 (authentication error)
       expect(response.status).not.toBe(401)
     })
 
@@ -220,19 +203,16 @@ describe('Admin Authentication', () => {
         method: 'GET'
       })
 
-      // Should not return 401 (may return other errors, but not auth error)
       const response = await executeRequest(app, request, env)
       expect(response.status).not.toBe(401)
     })
 
     it('should handle expired tokens', async () => {
-      // Create a token that appears expired
       const { hashToken } = await import('../../src/utils/crypto.js')
       const token = 'expired-token'
       const hashedToken = await hashToken(token)
       const storageKey = `${KV_KEYS.ADMIN_TOKEN_PREFIX}${hashedToken}`
-      
-      // Store token with old timestamp (expired)
+
       const oldTimestamp = Date.now() - (25 * 60 * 60 * 1000) // 25 hours ago
       await kv.put(storageKey, oldTimestamp.toString())
 
@@ -249,8 +229,3 @@ describe('Admin Authentication', () => {
     })
   })
 })
-
-
-
-
-


### PR DESCRIPTION
## Summary
- Authenticate `/api/admin/login` against `ADMIN_PASSWORD` with timing-safe compare (no KV password hash)
- Delete legacy `admin_token:password_hash` on successful login
- Surface distinct invalid-password vs rate-limit errors in the admin login UI

## Test plan
- [ ] `npm test -- --run tests/integration/admin-auth.test.js`
- [ ] Login succeeds with correct `ADMIN_PASSWORD` and fails with wrong password
- [ ] Rate limit still returns a clear error after 5 failures
- [ ] PaaS-deployed stores work after OpenShop-Service ships matching secret-only deploy
