### PR TITLE
UI/UX: unify brand blue, first-class Pages nav, sectioned product editor

### DIFF
--- a/docs/DESIGN-TOKENS.md
+++ b/docs/DESIGN-TOKENS.md
@@ -1,0 +1,141 @@
+# OpenShop — Design Tokens
+
+Canonical visual design language for the OpenShop product family. This file is the source of truth for color, typography, spacing, elevation, motion, iconography, and copy tone across all three surfaces:
+
+- **OpenShop-Lander** — marketing site (sells the product)
+- **OpenShop-Service** — PaaS dashboard (sign in → deploy stores)
+- **OpenShop** — admin dashboard (manage the store)
+
+The three surfaces must feel like one brand. Tokens are named here; each repo maps them onto its own styling system (Tailwind `@theme`, CSS custom properties, or `admin-theme.css` variables) without inventing new values.
+
+---
+
+## 1. Color
+
+One accent family: **cart-aligned blue** (navy → sky). No purple, violet, or indigo. No second accent.
+
+### Brand ramp (source of truth)
+
+| Token | Hex | Role |
+|-------|-----|------|
+| `brand-50`  | `#eff6ff` | tint backgrounds (rare, light contexts) |
+| `brand-100` | `#dbeafe` | subtle tint fills |
+| `brand-200` | `#bfdbfe` | hover tint borders |
+| `brand-300` | `#93c5fd` | active tint borders |
+| `brand-400` | `#60a5fa` | **primary-light** — secondary accents, links |
+| `brand-500` | `#3b82f6` | interactive hover accents |
+| `brand-600` | `#2563eb` | **primary** — buttons, active states, focus |
+| `brand-700` | `#1d4ed8` | primary pressed / hover-dark |
+| `brand-800` | `#1e40af` | deep accents |
+| `brand-900` | `#1e3a8a` | **primary-dark / navy** — deep hover, headers |
+| `brand-950` | `#172554` | navy backgrounds |
+
+**Existing repo mapping (do not rename):**
+- Lander / Service: `--color-primary: #2563eb` (= `brand-600`), `--color-primary-dark: #1e3a8a` (= `brand-900`), `--color-primary-light: #60a5fa` (= `brand-400`).
+- Admin (`admin-theme.css`): `--admin-accent` → `#2563eb`, `--admin-accent-hover` → `#1d4ed8`, `--admin-accent-light` → `#60a5fa`, `--admin-accent-dark` → `#1e3a8a`. Replace the legacy purple `#8b5cf6 / #7c3aed / #a78bfa / #6d28d9`.
+
+### Neutrals (cool zinc, dark base)
+
+| Token | Hex | Role |
+|-------|-----|------|
+| `surface-950` | `#09090b` | page background |
+| `surface-900` | `#18181b` | card / section surface |
+| `surface-800` | `#27272a` | borders, dividers |
+| `text-primary` | `#f4f4f5` | main text |
+| `text-secondary` | `#a1a1aa` | secondary text |
+| `text-muted` | `#71717a` | muted text, placeholders |
+
+### Semantic (shared, keep values)
+
+- `success` `#22c55e`, `warning` `#f59e0b`, `error` `#ef4444`, `info` `#3b82f6`.
+
+### Color rules
+
+- Accent saturation stays below ~80%. Blue is the only accent hue.
+- Backgrounds are tinted dark (`#09090b`), never pure `#000000`.
+- One consistent cool-gray family everywhere — no mixing warm and cool grays.
+
+---
+
+## 2. Typography
+
+- **Primary (body + UI):** `Plus Jakarta Sans` — weights 400 / 500 / 600 / 700 / 800.
+- **Display serif:** `DM Serif Display` — **only** for hero/display headlines on the **Lander**. Zero serif in Service and Admin dashboards.
+- **Numbers:** every price, metric, count, and stat uses `font-variant-numeric: tabular-nums` and the sans family — never serif, never proportional old-style digits.
+
+### Rules
+
+- Headlines: tight tracking (`tracking-tight`), `line-height` 1.05–1.1 for display, 1.15–1.25 for section heads.
+- Body: max ~65ch line length, `line-height` 1.6–1.7.
+- Labels/eyebrows: sentence case (not all-caps shouting); small, `tracking-wide`, `text-muted`.
+- Use 500/600 weights for hierarchy, not just 400 and 700.
+- `text-wrap: balance` on headlines, `text-wrap: pretty` on paragraphs.
+
+---
+
+## 3. Spacing & radius
+
+- Base unit `0.25rem` (4px). Section padding generous on the marketing surface (marketing breathes); tighter but consistent on dashboards.
+- Radius scale: `sm 0.375rem`, `DEFAULT 0.5rem`, `lg 0.75rem`, `xl 1rem`, `2xl 1.5rem`. Vary radius by context (tighter on inner controls, softer on containers) — avoid one uniform radius on everything.
+- Buttons: `0.5rem` (not fully pill everywhere; pill is reserved for a single primary marketing CTA if desired).
+
+---
+
+## 4. Elevation & material
+
+- **No glassmorphism.** Do not use `backdrop-filter: blur` panels. Remove existing `.glass-panel` blur treatments.
+- Surfaces read as real materials via layered background tone + a **tinted** shadow (brand-hue at low alpha), not a black `box-shadow`.
+- One ambient light source per page (e.g., a single top-right `brand` glow at low opacity). Do not scatter multiple gradient blobs.
+- Grain/noise (optional) via an inline SVG `feTurbulence` data-URI overlay at very low opacity — zero dependencies.
+- The Lander hero uses one dimensional focal object: a rendered storefront/checkout UI mock in brand tokens (sells the product). Never abstract 3D shapes or flat geometric blobs.
+
+---
+
+## 5. Motion
+
+- GPU-only: animate `transform` and `opacity` only. Never animate `top/left/width/height`.
+- Durations 200–300ms; `prefers-reduced-motion: reduce` disables.
+- Motion serves meaning: hover/press/focus affordances, state changes, and (on the marketing surface) a single load-in stagger. No decorative micro-animations, no hover that changes nothing.
+
+---
+
+## 6. Iconography
+
+- **No emojis** anywhere (code, markup, alt text, UI).
+- Admin (`OpenShop`): `lucide-react` (already installed).
+- Service (`OpenShop-Service`): inline SVG (no new dependency).
+- Lander (`OpenShop-Lander`): existing Material Symbols outline set (already loaded) or inline SVG. No new icon dependency.
+- Consistent stroke weight within a surface.
+
+---
+
+## 7. Copy tone
+
+- **Outcome-first:** lead with what the merchant keeps, gains, or saves — not what the product "does".
+- Sentence case (not Title Case). Active voice.
+- Forbidden clichés: "Elevate", "Seamless", "Unleash", "Next-Gen", "game-changer", "delve", "tapestry", "In the world of…".
+- No cutesy loader/status copy (e.g. "Checking the oil…", "Banging on the dash…"). One professional, static line per state.
+- No em-dash `"—"` used as a bullet glyph. Use real icon bullets.
+- Success messages: confident, no exclamation marks. Errors: direct ("We couldn't save your changes.").
+
+---
+
+## 8. Forbidden patterns (QA greps — must be zero after implementation)
+
+| Repo | Grep | Rationale |
+|------|------|-----------|
+| Admin `src/` | `8b5cf6`, `7c3aed`, `a78bfa`, `6d28d9`, `violet`, `purple` | kill legacy purple |
+| Lander `src/` | `backdrop-blur` | kill glassmorphism |
+| Lander `src/` | `rounded-full bg-gradient-to-br.*blur-3xl` (multiple gradient blobs) | kill scattered blobs |
+| Service `src/` | `Checking the oil`, `Wiring up the worker`, `Banging on the dash` | kill cutesy loader copy |
+| Service `src/` | `"—"` em-dash bullets in plan cards | real icons instead |
+| Lander + Service | `font-serif` on prices / numbers / metrics | serif is display-only (Lander hero) |
+| Service + Admin | `font-serif` in dashboard components | no serif in dashboards |
+| All | emojis in source / UI | icon sets only |
+
+---
+
+## 9. Scope boundaries
+
+- **OpenShop storefront** (`storefront-theme.css`, `src/pages/storefront/`, `src/components/storefront/`) is the customer-facing theme and is **out of scope**. Only the admin surface (`admin-theme.css`, `src/pages/admin/`, `src/components/admin/`, `src/components/ui/`) is redesigned.
+- Never commit built assets or secrets. OpenShop's `build.yml` owns `dist/` commits on main.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2,6 +2,8 @@
 
 How OpenShop code is organized for human and agent maintainability.
 
+> Canonical visual tokens (color ramp, typography, copy tone, forbidden patterns) live in [`DESIGN-TOKENS.md`](./DESIGN-TOKENS.md). This file covers layering and code boundaries only.
+
 ## Layer rules
 
 | Layer | Path | May import |

--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/cart.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
     <title>OpenShop</title>
   </head>
   <body>

--- a/src/components/admin/AdminLogin.jsx
+++ b/src/components/admin/AdminLogin.jsx
@@ -32,7 +32,7 @@ export function AdminLogin({ onLoginSuccess }) {
     <div className="min-h-screen flex items-center justify-center" style={{ background: 'linear-gradient(135deg, #0f1117 0%, #1a1d29 100%)' }}>
       <div className="w-full max-w-md p-8 rounded-xl" style={{ backgroundColor: '#1e212b', border: '1px solid #2d3748', boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.5)' }}>
         <div className="text-center mb-8">
-          <div className="w-12 h-12 mx-auto mb-4 rounded-lg flex items-center justify-center" style={{ background: 'linear-gradient(135deg, #6d28d9 0%, #8b5cf6 100%)' }}>
+          <div className="w-12 h-12 mx-auto mb-4 rounded-lg flex items-center justify-center" style={{ background: 'linear-gradient(135deg, #1e3a8a 0%, #2563eb 100%)' }}>
             <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
             </svg>

--- a/src/components/admin/AnalyticsCards.jsx
+++ b/src/components/admin/AnalyticsCards.jsx
@@ -5,12 +5,12 @@ import { TrendingUp, TrendingDown, DollarSign, ShoppingBag, BarChart3, Package }
 const iconStyles = {
   [DollarSign?.name || 'DollarSign']: { bg: 'rgba(34, 197, 94, 0.15)', color: '#22c55e' },
   [ShoppingBag?.name || 'ShoppingBag']: { bg: 'rgba(59, 130, 246, 0.15)', color: '#3b82f6' },
-  [BarChart3?.name || 'BarChart3']: { bg: 'rgba(139, 92, 246, 0.15)', color: '#a78bfa' },
+  [BarChart3?.name || 'BarChart3']: { bg: 'rgba(37, 99, 235, 0.15)', color: '#60a5fa' },
   [Package?.name || 'Package']: { bg: 'rgba(245, 158, 11, 0.15)', color: '#f59e0b' },
 }
 
 function getIconStyle(Icon) {
-  return iconStyles[Icon?.name] || { bg: 'rgba(139, 92, 246, 0.15)', color: '#a78bfa' }
+  return iconStyles[Icon?.name] || { bg: 'rgba(37, 99, 235, 0.15)', color: '#60a5fa' }
 }
 
 export function MetricCard({ title, value, change, changeType, icon: Icon, prefix = '' }) {
@@ -22,7 +22,7 @@ export function MetricCard({ title, value, change, changeType, icon: Icon, prefi
     <Card className="admin-stat-card relative overflow-hidden group">
       {/* Subtle gradient overlay */}
       <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" 
-           style={{ background: 'linear-gradient(135deg, rgba(139, 92, 246, 0.03) 0%, transparent 50%)' }} />
+           style={{ background: 'linear-gradient(135deg, rgba(37, 99, 235, 0.04) 0%, transparent 50%)' }} />
       
       <CardContent className="p-5 relative">
         <div className="flex items-center justify-between">
@@ -30,13 +30,13 @@ export function MetricCard({ title, value, change, changeType, icon: Icon, prefi
             <p className="text-xs font-medium uppercase tracking-wider mb-1 truncate" style={{ color: '#94a3b8' }}>
               {title}
             </p>
-            <p className="text-2xl font-bold truncate" style={{ color: '#e2e8f0', letterSpacing: '-0.02em' }}>
+            <p className="text-2xl font-bold truncate tabular-nums" style={{ color: '#e2e8f0', letterSpacing: '-0.02em' }}>
               {typeof value === 'number'
                 ? (prefix === '$' ? formatCurrency(value) : `${prefix}${value}`)
                 : `${prefix}${value}`}
             </p>
             {change !== undefined && (
-              <div className={`flex items-center mt-2 text-sm ${
+              <div className={`flex items-center mt-2 text-sm tabular-nums ${
                 isNeutral ? 'text-slate-500' : isPositive ? 'text-emerald-400' : 'text-red-400'
               }`}>
                 {!isNeutral && (
@@ -102,7 +102,7 @@ export function RecentOrdersCard({ orders }) {
                      className="p-3 rounded-lg transition-colors duration-200 hover:bg-white/5"
                      style={{ backgroundColor: '#242837', border: '1px solid #2d3748' }}>
                   <div className="flex items-center justify-between mb-2">
-                    <p className="text-sm font-semibold" style={{ color: '#e2e8f0' }}>
+                    <p className="text-sm font-semibold tabular-nums" style={{ color: '#e2e8f0' }}>
                       {formatCurrency(order.amount, order.currency)}
                     </p>
                     <span className="px-2 py-0.5 text-xs font-medium rounded-full" 

--- a/src/components/admin/AnalyticsCharts.jsx
+++ b/src/components/admin/AnalyticsCharts.jsx
@@ -23,7 +23,7 @@ export function RevenueChart({ data, period }) {
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
-          <div className="w-3 h-3 bg-gray-600 rounded-full"></div>
+          <div className="w-3 h-3 bg-blue-600 rounded-full"></div>
           Revenue Over Time
         </CardTitle>
       </CardHeader>
@@ -53,10 +53,10 @@ export function RevenueChart({ data, period }) {
               <Line 
                 type="monotone" 
                 dataKey="revenue" 
-                stroke="#9333ea" 
+                stroke="#2563eb" 
                 strokeWidth={3}
-                dot={{ fill: '#9333ea', strokeWidth: 2, r: 4 }}
-                activeDot={{ r: 6, stroke: '#9333ea', strokeWidth: 2 }}
+                dot={{ fill: '#2563eb', strokeWidth: 2, r: 4 }}
+                activeDot={{ r: 6, stroke: '#2563eb', strokeWidth: 2 }}
               />
             </LineChart>
           </ResponsiveContainer>

--- a/src/components/admin/AnalyticsCharts.jsx
+++ b/src/components/admin/AnalyticsCharts.jsx
@@ -34,16 +34,17 @@ export function RevenueChart({ data, period }) {
               <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
               <XAxis 
                 dataKey="formattedDate" 
-                tick={{ fontSize: 12 }}
+                tick={{ fontSize: 12, style: { fontVariantNumeric: 'tabular-nums' } }}
                 tickFormatter={formatXAxisLabel}
               />
               <YAxis 
-                tick={{ fontSize: 12 }}
+                tick={{ fontSize: 12, style: { fontVariantNumeric: 'tabular-nums' } }}
                 tickFormatter={(value) => `$${value}`}
               />
               <Tooltip 
                 formatter={formatTooltip}
-                labelStyle={{ color: '#374151' }}
+                labelStyle={{ color: '#374151', fontVariantNumeric: 'tabular-nums' }}
+                itemStyle={{ fontVariantNumeric: 'tabular-nums' }}
                 contentStyle={{ 
                   backgroundColor: 'white', 
                   border: '1px solid #e5e7eb',
@@ -90,13 +91,14 @@ export function OrdersChart({ data, period }) {
               <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
               <XAxis 
                 dataKey="formattedDate" 
-                tick={{ fontSize: 12 }}
+                tick={{ fontSize: 12, style: { fontVariantNumeric: 'tabular-nums' } }}
                 tickFormatter={formatXAxisLabel}
               />
-              <YAxis tick={{ fontSize: 12 }} />
+              <YAxis tick={{ fontSize: 12, style: { fontVariantNumeric: 'tabular-nums' } }} />
               <Tooltip 
                 formatter={(value, name) => [value, 'Orders']}
-                labelStyle={{ color: '#374151' }}
+                labelStyle={{ color: '#374151', fontVariantNumeric: 'tabular-nums' }}
+                itemStyle={{ fontVariantNumeric: 'tabular-nums' }}
                 contentStyle={{ 
                   backgroundColor: 'white', 
                   border: '1px solid #e5e7eb',

--- a/src/components/admin/CollectionForm.jsx
+++ b/src/components/admin/CollectionForm.jsx
@@ -102,7 +102,7 @@ export function CollectionForm({ collection, onSave, onCancel }) {
   return (
     <>
     <div className="w-full max-w-4xl mx-auto space-y-6">
-      <div className="sticky top-0 z-20 px-6 py-4 bg-[var(--admin-bg-card)]/95 backdrop-blur border border-[var(--admin-border-primary)] rounded-lg flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="sticky top-0 z-20 px-6 py-4 bg-[var(--admin-bg-card)] border border-[var(--admin-border-primary)] rounded-lg flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="text-xl font-semibold text-[var(--admin-text-primary)]">{collection ? 'Edit Collection' : 'Create New Collection'}</h2>
           <p className="text-sm text-[var(--admin-text-secondary)]">Organize products into collections with names, descriptions, and hero imagery.</p>

--- a/src/components/admin/ProductWorkspace.jsx
+++ b/src/components/admin/ProductWorkspace.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react"
+import { useState, useEffect, useMemo, useRef } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { Card, CardHeader, CardTitle, CardContent } from "../ui/card"
 import { Button } from "../ui/button"
@@ -81,6 +81,14 @@ const prepareVariantsForSave = (variants = []) =>
         price: variant.hasCustomPrice ? (Number.isFinite(parsedPrice) ? parsedPrice : 0) : undefined,
       }
     })
+
+const PRODUCT_SECTIONS = [
+  { id: "product-section-overview", label: "Overview" },
+  { id: "product-section-pricing", label: "Pricing" },
+  { id: "product-section-media", label: "Media" },
+  { id: "product-section-collections", label: "Collections" },
+  { id: "product-section-variants", label: "Variants" },
+]
 function VariantGroupEditor({
   id,
   title,
@@ -291,6 +299,9 @@ export function ProductWorkspace() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [pendingSelection, setPendingSelection] = useState(null)
   const [unsavedDialogOpen, setUnsavedDialogOpen] = useState(false)
+  const [activeSection, setActiveSection] = useState(PRODUCT_SECTIONS[0].id)
+  const [headerOffset, setHeaderOffset] = useState(160)
+  const headerRef = useRef(null)
 
   const isDirty = draftFingerprint(draft) !== draftFingerprint(baselineDraft)
 
@@ -462,6 +473,40 @@ export function ProductWorkspace() {
     const timer = setTimeout(() => setStatus(null), 4000)
     return () => clearTimeout(timer)
   }, [status])
+
+  useEffect(() => {
+    if (!headerRef.current) return
+    const observer = new ResizeObserver((entries) => {
+      const height = entries[0]?.contentRect?.height
+      if (height) setHeaderOffset(Math.ceil(height) + 16)
+    })
+    observer.observe(headerRef.current)
+    return () => observer.disconnect()
+  }, [draft])
+
+  useEffect(() => {
+    if (!draft) return
+    const sectionEls = PRODUCT_SECTIONS.map((section) => document.getElementById(section.id)).filter(Boolean)
+    if (sectionEls.length === 0) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) setActiveSection(entry.target.id)
+        })
+      },
+      { rootMargin: '-30% 0px -60% 0px' }
+    )
+    sectionEls.forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [draft])
+
+  const scrollToSection = (id) => {
+    const el = document.getElementById(id)
+    if (!el) return
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    el.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' })
+    setActiveSection(id)
+  }
   const handleRefresh = async () => {
     try {
       setIsLoading(true)
@@ -907,7 +952,7 @@ export function ProductWorkspace() {
 
           {draft ? (
             <div className="space-y-5 pb-16">
-              <Card className="sticky top-0 z-20 border border-[var(--admin-border-primary)]">
+              <Card ref={headerRef} className="sticky top-0 z-20 border border-[var(--admin-border-primary)]">
                 <CardHeader className="gap-4 md:flex-row md:items-center md:justify-between py-4">
                   <div className="space-y-1">
                     <CardTitle className="text-lg">
@@ -953,10 +998,29 @@ export function ProductWorkspace() {
                     </Button>
                   </div>
                 </CardHeader>
+                <div className="border-t border-[var(--admin-border-primary)] px-3 py-2">
+                  <nav aria-label="Product sections" className="flex flex-wrap items-center gap-1">
+                    {PRODUCT_SECTIONS.map((section) => (
+                      <button
+                        key={section.id}
+                        type="button"
+                        onClick={() => scrollToSection(section.id)}
+                        aria-current={activeSection === section.id ? 'true' : undefined}
+                        className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                          activeSection === section.id
+                            ? 'bg-[var(--admin-accent)]/15 text-[var(--admin-accent-light)]'
+                            : 'text-[var(--admin-text-secondary)] hover:bg-[var(--admin-overlay-light)] hover:text-[var(--admin-text-primary)]'
+                        }`}
+                      >
+                        {section.label}
+                      </button>
+                    ))}
+                  </nav>
+                </div>
               </Card>
 
               <div className="grid gap-5 xl:grid-cols-2">
-                <Card>
+                <Card id="product-section-overview" style={{ scrollMarginTop: headerOffset }}>
                   <CardHeader className="py-4">
                     <CardTitle className="text-base">Product overview</CardTitle>
                     <p className="text-xs text-[var(--admin-text-secondary)]">
@@ -996,7 +1060,7 @@ export function ProductWorkspace() {
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card id="product-section-pricing" style={{ scrollMarginTop: headerOffset }}>
                   <CardHeader className="py-4">
                     <CardTitle className="text-base">Pricing & visibility</CardTitle>
                     <p className="text-xs text-[var(--admin-text-secondary)]">
@@ -1048,7 +1112,7 @@ export function ProductWorkspace() {
                   </CardContent>
                 </Card>
 
-                <Card className="xl:col-span-2">
+                <Card id="product-section-media" style={{ scrollMarginTop: headerOffset }} className="xl:col-span-2">
                   <CardHeader className="py-4">
                     <CardTitle className="text-base">Media</CardTitle>
                     <p className="text-xs text-[var(--admin-text-secondary)]">
@@ -1087,7 +1151,7 @@ export function ProductWorkspace() {
                   </CardContent>
                 </Card>
 
-                <Card className="xl:col-span-2">
+                <Card id="product-section-collections" style={{ scrollMarginTop: headerOffset }} className="xl:col-span-2">
                   <CardHeader className="py-4">
                     <CardTitle className="text-base">Collections & metadata</CardTitle>
                     <p className="text-xs text-[var(--admin-text-secondary)]">
@@ -1114,7 +1178,7 @@ export function ProductWorkspace() {
                   </CardContent>
                 </Card>
 
-                <Card className="xl:col-span-2">
+                <Card id="product-section-variants" style={{ scrollMarginTop: headerOffset }} className="xl:col-span-2">
                   <CardHeader className="py-4">
                     <CardTitle className="text-base">Variants</CardTitle>
                     <p className="text-xs text-[var(--admin-text-secondary)]">

--- a/src/components/admin/ProductWorkspace.jsx
+++ b/src/components/admin/ProductWorkspace.jsx
@@ -248,7 +248,7 @@ function ProductListItem({ product, isActive, onSelect, collectionName }) {
             <span className="font-medium text-[var(--admin-text-primary)] text-sm truncate">
               {product.name || 'Untitled product'}
             </span>
-            <span className="text-xs font-semibold text-[var(--admin-text-secondary)]">
+            <span className="text-xs font-semibold text-[var(--admin-text-secondary)] tabular-nums">
               {formatCurrency(product.price, product.currency)}
             </span>
           </div>
@@ -474,6 +474,8 @@ export function ProductWorkspace() {
     return () => clearTimeout(timer)
   }, [status])
 
+  const hasDraft = draft != null
+
   useEffect(() => {
     if (!headerRef.current) return
     const observer = new ResizeObserver((entries) => {
@@ -482,23 +484,24 @@ export function ProductWorkspace() {
     })
     observer.observe(headerRef.current)
     return () => observer.disconnect()
-  }, [draft])
+  }, [hasDraft])
 
   useEffect(() => {
-    if (!draft) return
+    if (!hasDraft) return
     const sectionEls = PRODUCT_SECTIONS.map((section) => document.getElementById(section.id)).filter(Boolean)
     if (sectionEls.length === 0) return
     const observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) setActiveSection(entry.target.id)
-        })
+        const topMost = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)[0]
+        if (topMost) setActiveSection(topMost.target.id)
       },
       { rootMargin: '-30% 0px -60% 0px' }
     )
     sectionEls.forEach((el) => observer.observe(el))
     return () => observer.disconnect()
-  }, [draft])
+  }, [hasDraft])
 
   const scrollToSection = (id) => {
     const el = document.getElementById(id)
@@ -1005,8 +1008,8 @@ export function ProductWorkspace() {
                         key={section.id}
                         type="button"
                         onClick={() => scrollToSection(section.id)}
-                        aria-current={activeSection === section.id ? 'true' : undefined}
-                        className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                        aria-current={activeSection === section.id ? 'location' : undefined}
+                        className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--admin-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--admin-bg-primary)] ${
                           activeSection === section.id
                             ? 'bg-[var(--admin-accent)]/15 text-[var(--admin-accent-light)]'
                             : 'text-[var(--admin-text-secondary)] hover:bg-[var(--admin-overlay-light)] hover:text-[var(--admin-text-primary)]'

--- a/src/components/admin/StoreSettingsEditor.jsx
+++ b/src/components/admin/StoreSettingsEditor.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Input } from '../ui/input'
 import { Button } from '../ui/button'
 import { Select } from '../ui/select'
@@ -24,8 +24,6 @@ import {
 } from '../ui/alert-dialog'
 import { Image as ImageIcon, Info, MapPin, Paintbrush } from 'lucide-react'
 
-const PuckPageEditor = lazy(() => import('./PuckPageEditor').then((module) => ({ default: module.PuckPageEditor })))
-
 const DEFAULT_SETTINGS = {
   logoType: 'text',
   logoText: 'OpenShop',
@@ -50,7 +48,6 @@ const DEFAULT_SETTINGS = {
 }
 
 export function StoreSettingsEditor() {
-  const [activeTab, setActiveTab] = useState('settings')
   const [activeSection, setActiveSection] = useState('theme')
   const [settings, setSettings] = useState(DEFAULT_SETTINGS)
   const [settingsBaseline, setSettingsBaseline] = useState(null)
@@ -280,25 +277,12 @@ export function StoreSettingsEditor() {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h2 className="text-lg font-semibold text-[var(--admin-text-primary)]">Store settings</h2>
-            <p className="text-xs text-[var(--admin-text-muted)]">Manage brand settings and edit storefront pages.</p>
-          </div>
-          <div className="inline-flex rounded-md border border-[var(--admin-border-primary)] bg-[var(--admin-bg-elevated)] p-1">
-            <Button type="button" size="sm" variant={activeTab === 'settings' ? 'default' : 'ghost'} onClick={() => setActiveTab('settings')} className="h-8 px-3 text-xs">
-              Brand & Theme
-            </Button>
-            <Button type="button" size="sm" variant={activeTab === 'pages' ? 'default' : 'ghost'} onClick={() => setActiveTab('pages')} className="h-8 px-3 text-xs">
-              Pages
-            </Button>
+            <p className="text-xs text-[var(--admin-text-muted)]">Manage brand, theme, and store identity.</p>
           </div>
         </div>
       </div>
 
-      {activeTab === 'pages' ? (
-        <Suspense fallback={<div className="rounded-lg border border-[var(--admin-border-primary)] bg-[var(--admin-bg-card)] p-6 text-sm text-[var(--admin-text-muted)]">Loading page editor...</div>}>
-          <PuckPageEditor />
-        </Suspense>
-      ) : (
-        <form onSubmit={handleSubmit} className="grid gap-4 xl:grid-cols-[320px_minmax(0,1fr)]">
+      <form onSubmit={handleSubmit} className="grid gap-4 xl:grid-cols-[320px_minmax(0,1fr)]">
           <div className="rounded-xl border border-[var(--admin-border-primary)] bg-[var(--admin-bg-secondary)] p-4 shadow-sm">
             <div className="grid gap-2">
               {sections.map((item) => {
@@ -452,7 +436,6 @@ export function StoreSettingsEditor() {
             </div>
           </div>
         </form>
-      )}
 
       {modalImage && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70" onClick={() => setModalImage(null)}>

--- a/src/middleware/securityHeaders.js
+++ b/src/middleware/securityHeaders.js
@@ -19,9 +19,9 @@ export async function securityHeadersMiddleware(c, next) {
   const csp = [
     "default-src 'self'",
     "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com", // Stripe requires unsafe-inline
-    "style-src 'self' 'unsafe-inline'",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https: blob:",
-    "font-src 'self' data:",
+    "font-src 'self' data: https://fonts.gstatic.com",
     "connect-src 'self' https://api.stripe.com https://*.stripe.com https://oauth2.googleapis.com https://www.googleapis.com",
     "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
     "frame-ancestors 'none'",

--- a/src/pages/admin/AdminDashboard.jsx
+++ b/src/pages/admin/AdminDashboard.jsx
@@ -8,6 +8,7 @@ import { ProductsPage } from './ProductsPage'
 import { CollectionsPage } from './CollectionsPage'
 import { MediaLibraryPage } from './MediaLibraryPage'
 import { StoreSettingsPage } from './StoreSettingsPage'
+import { PagesPage } from './PagesPage'
 import { FulfillmentPage } from './FulfillmentPage'
 
 export function AdminDashboard() {
@@ -61,6 +62,7 @@ export function AdminDashboard() {
         <Route path="Fulfillment" element={<FulfillmentPage />} />
         <Route path="media" element={<MediaLibraryPage />} />
         <Route path="store-settings" element={<StoreSettingsPage />} />
+        <Route path="pages" element={<PagesPage />} />
       </Route>
     </Routes>
   )

--- a/src/pages/admin/AdminLayout.jsx
+++ b/src/pages/admin/AdminLayout.jsx
@@ -54,7 +54,8 @@ export function AdminLayout({ onLogout }) {
                 <li key={item.path}>
                   <Link
                     to={item.path}
-                    className={`flex items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-all duration-200 ${
+                    aria-current={isActive ? 'page' : undefined}
+                    className={`flex items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--admin-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--admin-bg-primary)] ${
                       isActive
                         ? 'bg-[var(--admin-accent)]/15 text-[var(--admin-accent-light)] border-l-2 border-[var(--admin-accent)]'
                         : 'text-[var(--admin-text-secondary)] hover:bg-[var(--admin-overlay-light)] hover:text-[var(--admin-text-primary)]'

--- a/src/pages/admin/AdminLayout.jsx
+++ b/src/pages/admin/AdminLayout.jsx
@@ -7,6 +7,7 @@ import {
   Settings,
   ShoppingBag,
   Image as ImageIcon,
+  LayoutTemplate,
   LogOut,
   Store,
 } from 'lucide-react'
@@ -18,6 +19,7 @@ const menuItems = [
   { path: '/admin/fulfillment', label: 'Fulfillment', icon: ShoppingBag },
   { path: '/admin/media', label: 'Media', icon: ImageIcon },
   { path: '/admin/store-settings', label: 'Store Settings', icon: Settings },
+  { path: '/admin/pages', label: 'Pages', icon: LayoutTemplate },
 ]
 
 function isNavActive(pathname, item) {
@@ -44,7 +46,7 @@ export function AdminLayout({ onLogout }) {
           </Link>
         </div>
         <nav className="flex-1 p-3">
-          <ul className="flex gap-1 overflow-x-auto lg:block lg:space-y-1">
+          <ul className="grid grid-cols-2 gap-1 sm:grid-cols-3 lg:block lg:space-y-1">
             {menuItems.map((item) => {
               const Icon = item.icon
               const isActive = isNavActive(location.pathname, item)
@@ -52,14 +54,14 @@ export function AdminLayout({ onLogout }) {
                 <li key={item.path}>
                   <Link
                     to={item.path}
-                    className={`flex whitespace-nowrap items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-all duration-200 ${
+                    className={`flex items-center gap-3 px-3 py-2.5 rounded-md text-sm transition-all duration-200 ${
                       isActive
                         ? 'bg-[var(--admin-accent)]/15 text-[var(--admin-accent-light)] border-l-2 border-[var(--admin-accent)]'
                         : 'text-[var(--admin-text-secondary)] hover:bg-[var(--admin-overlay-light)] hover:text-[var(--admin-text-primary)]'
                     }`}
                   >
-                    <Icon className="w-4 h-4" />
-                    <span>{item.label}</span>
+                    <Icon className="w-4 h-4 flex-shrink-0" />
+                    <span className="truncate">{item.label}</span>
                   </Link>
                 </li>
               )

--- a/src/pages/admin/DashboardPage.jsx
+++ b/src/pages/admin/DashboardPage.jsx
@@ -144,7 +144,7 @@ export function DashboardPage() {
                       >
                         <div>
                           <h4 className="font-medium text-[var(--admin-text-primary)] text-sm">{product.name}</h4>
-                          <p className="text-xs text-[var(--admin-text-secondary)]">
+                          <p className="text-xs text-[var(--admin-text-secondary)] tabular-nums">
                             {formatCurrency(product.price, product.currency)}
                           </p>
                         </div>

--- a/src/pages/admin/FulfillmentPage.jsx
+++ b/src/pages/admin/FulfillmentPage.jsx
@@ -517,7 +517,7 @@ export function FulfillmentPage() {
                             )}
                           </div>
                         )}
-                        <p className="text-xs text-[var(--admin-text-secondary)]">Quantity: {item.quantity}</p>
+                        <p className="text-xs text-[var(--admin-text-secondary)] tabular-nums">Quantity: {item.quantity}</p>
                       </div>
                       <div className="text-right">
                         <p className="font-medium text-[var(--admin-text-primary)] text-sm tabular-nums">

--- a/src/pages/admin/FulfillmentPage.jsx
+++ b/src/pages/admin/FulfillmentPage.jsx
@@ -3,7 +3,7 @@ import { Button } from '../../components/ui/button'
 import { Card, CardContent } from '../../components/ui/card'
 import { formatCurrency } from '../../lib/utils'
 import { adminApiRequest } from '../../lib/auth'
-import { X } from 'lucide-react'
+import { X, ShoppingBag, Check } from 'lucide-react'
 
 export function FulfillmentPage() {
   const [orders, setOrders] = useState([])
@@ -292,7 +292,17 @@ export function FulfillmentPage() {
         </Card>
       ) : orders.length === 0 ? (
         <Card>
-          <CardContent className="p-12 text-center text-[var(--admin-text-muted)]">No orders found.</CardContent>
+          <CardContent className="p-12 text-center">
+            <ShoppingBag className="w-12 h-12 text-[var(--admin-border-secondary)] mx-auto mb-4" />
+            <h3 className="text-base font-medium text-[var(--admin-text-primary)] mb-2">
+              {statusFilter === 'open' ? 'No open orders' : statusFilter === 'fulfilled' ? 'No fulfilled orders' : 'No orders yet'}
+            </h3>
+            <p className="text-[var(--admin-text-secondary)] text-sm">
+              {statusFilter === 'fulfilled'
+                ? 'Orders you fulfill will appear here.'
+                : 'Orders will appear here after a customer completes checkout.'}
+            </p>
+          </CardContent>
         </Card>
       ) : (
         <div className="space-y-4">
@@ -335,8 +345,9 @@ export function FulfillmentPage() {
                           {order.customer_email || ''}
                         </span>
                         {order.fulfillment?.fulfilled && (
-                          <span className="text-xs text-[var(--admin-success)] font-medium mt-1">
-                            ✓ Fulfilled{' '}
+                          <span className="inline-flex items-center gap-1 text-xs text-[var(--admin-success)] font-medium mt-1">
+                            <Check className="h-3.5 w-3.5" />
+                            Fulfilled{' '}
                             {order.fulfillment.fulfilledAt
                               ? new Date(order.fulfillment.fulfilledAt).toLocaleDateString()
                               : ''}
@@ -344,7 +355,7 @@ export function FulfillmentPage() {
                         )}
                       </div>
                       <div className="flex items-center gap-3">
-                        <div className="text-right font-semibold text-[var(--admin-text-primary)] text-sm">
+                        <div className="text-right font-semibold text-[var(--admin-text-primary)] text-sm tabular-nums">
                           {formatCurrency(
                             (order.amount_total || 0) / 100,
                             order.currency?.toUpperCase() || 'USD'
@@ -423,7 +434,7 @@ export function FulfillmentPage() {
                       <span className="text-[var(--admin-text-muted)]">Order Date:</span>{' '}
                       {new Date(selectedOrder.created * 1000).toLocaleString()}
                     </p>
-                    <p className="text-[var(--admin-text-secondary)]">
+                    <p className="text-[var(--admin-text-secondary)] tabular-nums">
                       <span className="text-[var(--admin-text-muted)]">Total:</span>{' '}
                       {formatCurrency(
                         (selectedOrder.amount_total || 0) / 100,
@@ -431,8 +442,9 @@ export function FulfillmentPage() {
                       )}
                     </p>
                     {selectedOrder.fulfillment?.fulfilled && (
-                      <p className="text-[var(--admin-success)] font-medium text-sm">
-                        ✓ Fulfilled on {new Date(selectedOrder.fulfillment.fulfilledAt).toLocaleDateString()}
+                      <p className="inline-flex items-center gap-1 text-[var(--admin-success)] font-medium text-sm">
+                        <Check className="h-4 w-4" />
+                        Fulfilled on {new Date(selectedOrder.fulfillment.fulfilledAt).toLocaleDateString()}
                       </p>
                     )}
                   </div>
@@ -508,7 +520,7 @@ export function FulfillmentPage() {
                         <p className="text-xs text-[var(--admin-text-secondary)]">Quantity: {item.quantity}</p>
                       </div>
                       <div className="text-right">
-                        <p className="font-medium text-[var(--admin-text-primary)] text-sm">
+                        <p className="font-medium text-[var(--admin-text-primary)] text-sm tabular-nums">
                           {formatCurrency(
                             (item.amount_total || 0) / 100,
                             item.currency?.toUpperCase() || 'USD'
@@ -525,8 +537,9 @@ export function FulfillmentPage() {
               {!selectedOrder.fulfillment?.fulfilled ? (
                 <div className="text-sm text-[var(--admin-text-secondary)]">This order is ready for fulfillment</div>
               ) : (
-                <div className="text-sm text-[var(--admin-success)] font-medium">
-                  ✓ Order fulfilled on {new Date(selectedOrder.fulfillment.fulfilledAt).toLocaleDateString()}
+                <div className="inline-flex items-center gap-1 text-sm text-[var(--admin-success)] font-medium">
+                  <Check className="h-4 w-4" />
+                  Order fulfilled on {new Date(selectedOrder.fulfillment.fulfilledAt).toLocaleDateString()}
                 </div>
               )}
               <div className="flex gap-2">

--- a/src/pages/admin/MediaLibraryPage.jsx
+++ b/src/pages/admin/MediaLibraryPage.jsx
@@ -88,9 +88,13 @@ export function MediaLibraryPage() {
           <CardContent className="p-12 text-center">
             <ImageIcon className="w-12 h-12 text-[var(--admin-border-secondary)] mx-auto mb-4" />
             <h3 className="text-base font-medium text-[var(--admin-text-primary)] mb-2">No media yet</h3>
-            <p className="text-[var(--admin-text-secondary)] text-sm">
-              Use Add media to upload, link, or generate images.
+            <p className="text-[var(--admin-text-secondary)] text-sm mb-6">
+              Upload, link, or generate images to use across products and pages.
             </p>
+            <Button onClick={() => setAddOpen(true)} size="sm">
+              <Plus className="w-4 h-4 mr-2" />
+              Add media
+            </Button>
           </CardContent>
         </Card>
       ) : (

--- a/src/pages/admin/PagesPage.jsx
+++ b/src/pages/admin/PagesPage.jsx
@@ -1,0 +1,27 @@
+import { lazy, Suspense } from 'react'
+
+const PuckPageEditor = lazy(() =>
+  import('../../components/admin/PuckPageEditor').then((module) => ({ default: module.PuckPageEditor }))
+)
+
+export function PagesPage() {
+  return (
+    <div className="space-y-5">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-bold text-[var(--admin-text-primary)]">Pages</h1>
+        <p className="text-xs text-[var(--admin-text-secondary)]">
+          Build the Home and About pages with reusable storefront blocks.
+        </p>
+      </div>
+      <Suspense
+        fallback={
+          <div className="rounded-lg border border-[var(--admin-border-primary)] bg-[var(--admin-bg-card)] p-6 text-sm text-[var(--admin-text-muted)]">
+            Loading page editor...
+          </div>
+        }
+      >
+        <PuckPageEditor />
+      </Suspense>
+    </div>
+  )
+}

--- a/src/styles/admin-theme.css
+++ b/src/styles/admin-theme.css
@@ -22,11 +22,11 @@
   --admin-border-secondary: #374151;
   --admin-border-focus: #4b5563;
   
-  /* Accent colors - Purple (keeping brand identity) */
-  --admin-accent: #8b5cf6;
-  --admin-accent-hover: #7c3aed;
-  --admin-accent-light: #a78bfa;
-  --admin-accent-dark: #6d28d9;
+  /* Accent colors - Brand blue (cart-aligned, per docs/DESIGN-TOKENS.md) */
+  --admin-accent: #2563eb;
+  --admin-accent-hover: #1d4ed8;
+  --admin-accent-light: #60a5fa;
+  --admin-accent-dark: #1e3a8a;
   
   /* Semantic colors */
   --admin-success: #22c55e;
@@ -46,7 +46,7 @@
   --admin-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
   --admin-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.3);
   --admin-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -2px rgba(0, 0, 0, 0.4);
-  --admin-shadow-glow: 0 0 20px rgba(139, 92, 246, 0.15);
+  --admin-shadow-glow: 0 0 20px rgba(37, 99, 235, 0.15);
   
   /* Spacing scale - more compact */
   --admin-space-1: 0.25rem;
@@ -73,6 +73,12 @@
   background-color: var(--admin-bg-primary);
   color: var(--admin-text-primary);
   min-height: 100vh;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+}
+
+/* Numeric alignment for metrics, prices, counts, and stats */
+.admin-tabular-nums {
+  font-variant-numeric: tabular-nums;
 }
 
 /* Sidebar styles */
@@ -99,7 +105,7 @@
 }
 
 .admin-sidebar-link.active {
-  background-color: rgba(139, 92, 246, 0.15);
+  background-color: rgba(37, 99, 235, 0.15);
   color: var(--admin-accent-light);
   border-left: 3px solid var(--admin-accent);
 }
@@ -150,7 +156,7 @@
 .admin-input:focus {
   outline: none;
   border-color: var(--admin-accent);
-  box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.2);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
 }
 
 .admin-input:disabled {
@@ -178,7 +184,7 @@
 .admin-select:focus {
   outline: none;
   border-color: var(--admin-accent);
-  box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.2);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
 }
 
 .admin-select option {
@@ -266,7 +272,7 @@
 .admin-textarea:focus {
   outline: none;
   border-color: var(--admin-accent);
-  box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.2);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
 }
 
 /* Switch styles */

--- a/src/worker.js
+++ b/src/worker.js
@@ -99,7 +99,7 @@ app.get('*', async (c) => {
               font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
               text-align: center; 
               padding: 50px 20px; 
-              background: linear-gradient(135deg, #9333ea 0%, #2563eb 100%);
+              background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 100%);
               color: white;
               margin: 0;
               min-height: 100vh;


### PR DESCRIPTION
## What changed

Overhauled the admin dashboard navigation and consistency.

- **Unified brand**: replaced the legacy purple accent with the cart-aligned blue ramp (`#2563eb`/`#1e3a8a`/`#60a5fa`), loaded Plus Jakarta Sans (CSP updated so it actually loads in production), tabular-nums on metrics. Purple fully eliminated across `src/` including the worker error-fallback.
- **First-class Pages nav**: the Puck page editor is now one click away from the sidebar (lazy-loaded, code-split) instead of buried inside Store Settings → Pages tab.
- **Store Settings**: flattened to a single-level section nav (Theme / Identity / Info / Contact); removed the confusing top-level Pages tab.
- **Product editor sectioning**: added a sticky section tab bar (Overview / Pricing / Media / Collections / Variants) with deterministic scroll-spy — **zero changes** to save/dirty/unsaved-guard logic.
- **Mobile nav**: horizontal-scroll list replaced with a wrapping grid.
- **Consistency**: designed empty states (Fulfillment, Media), page-header alignment across Collections/Media/Fulfillment.

Design contract: `docs/DESIGN-TOKENS.md`. Storefront (customer-facing theme) is untouched.

## Verification
- `npm run lint:harness` ✅
- `npm run harness:validate` ✅ (architecture layers OK)
- `npm test -- --run` ✅ (215/215)
- `npm run build` ✅
- Adversarial review findings resolved (CSP font block, `#9333ea` fallback, scroll-spy determinism, aria-current, observer churn)

Note: `npm run lint` (full) has 39 pre-existing errors in `tests/*.test.js` — out of CI scope, unchanged.