### PR TITLE
Fix Store Agent models fetch and default to Ox Alpha

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,7 +34,7 @@ DRIVE_ROOT_FOLDER=OpenShop
 # products, collections, and pages on behalf of the merchant.
 OPENROUTER_API_KEY=your_openrouter_api_key
 # Optional: override the default agent model (any OpenRouter model ID)
-OPENROUTER_MODEL=openai/gpt-4o-mini
+OPENROUTER_MODEL=stealth/ox-alpha
 ```
 
 ## Cloudflare Setup

--- a/src/components/admin/AgentChat.jsx
+++ b/src/components/admin/AgentChat.jsx
@@ -29,7 +29,7 @@ export function AgentChat() {
   useEffect(() => {
     let cancelled = false
     adminAPI
-      .models()
+      .agent.models()
       .then((data) => {
         if (cancelled) return
         setConfigured(data.configured !== false)

--- a/src/routes/admin/agent.js
+++ b/src/routes/admin/agent.js
@@ -16,7 +16,7 @@ export function setAgentApp(app) {
 }
 
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1'
-const DEFAULT_MODEL = 'openai/gpt-4o-mini'
+const DEFAULT_MODEL = 'stealth/ox-alpha'
 const MAX_TOOL_ITERATIONS = 8
 
 const PAGE_COMPONENTS_DOC = `Page builder components (each content item is { "type": string, "props": object }):


### PR DESCRIPTION
## Summary
- Call `adminAPI.agent.models()` so a keyed store shows the chat UI instead of the missing-key empty state
- Default the Store Agent to OpenRouter `stealth/ox-alpha`

## Test plan
- [ ] Open admin dashboard with `OPENROUTER_API_KEY` set: Store Agent loads models and chat
- [ ] Without the key: still shows the unconfigured empty state
- [ ] Default selected model is Ox Alpha; other models remain selectable

Local: harness validate and `npm test -- --run` (249 tests) passed.

Made with [Cursor](https://cursor.com)