### PR TITLE
fix: render Store Agent chat on dashboard regardless of analytics state

### DIFF
--- a/src/pages/admin/DashboardPage.jsx
+++ b/src/pages/admin/DashboardPage.jsx
@@ -124,7 +124,6 @@ export function DashboardPage() {
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             <RecentOrdersCard orders={analytics.recentOrders} />
-            <AgentChat />
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
@@ -177,6 +176,10 @@ export function DashboardPage() {
           </CardContent>
         </Card>
       )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <AgentChat />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
The Store Agent (AgentChat) was only rendered inside the analytics-present branch of DashboardPage, so it vanished whenever analytics was null (no orders yet) or the analytics fetch failed. Moved it to an unconditional row so owners always see the agent UI.