### PR TITLE
fix: switch default agent model to z-ai/glm-5.3-flash

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,7 +34,7 @@ DRIVE_ROOT_FOLDER=OpenShop
 # products, collections, and pages on behalf of the merchant.
 OPENROUTER_API_KEY=your_openrouter_api_key
 # Optional: override the default agent model (any OpenRouter model ID)
-OPENROUTER_MODEL=stealth/ox-alpha
+OPENROUTER_MODEL=z-ai/glm-5.3-flash
 ```
 
 ## Cloudflare Setup

--- a/src/routes/admin/agent.js
+++ b/src/routes/admin/agent.js
@@ -16,7 +16,7 @@ export function setAgentApp(app) {
 }
 
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1'
-const DEFAULT_MODEL = 'stealth/ox-alpha'
+const DEFAULT_MODEL = 'z-ai/glm-5.3-flash'
 const MAX_TOOL_ITERATIONS = 8
 
 const PAGE_COMPONENTS_DOC = `Page builder components (each content item is { "type": string, "props": object }):


### PR DESCRIPTION
## Summary
- `stealth/ox-alpha` was delisted from OpenRouter and returns 404 on all Store Agent requests
- Switches the default agent model to `z-ai/glm-5.3-flash` (code constant + docs)

## Changes
- src/routes/admin/agent.js — DEFAULT_MODEL fallback
- docs/CONFIGURATION.md — documented default

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)